### PR TITLE
use pandas instead of numpy max function

### DIFF
--- a/pandapipes/component_models/junction_component.py
+++ b/pandapipes/component_models/junction_component.py
@@ -54,7 +54,7 @@ class Junction(NodeComponent):
         end = current_start + table_len
         ft_lookups[cls.table_name()] = (current_start, end)
         add_table_lookup(table_lookup, cls.table_name(), current_table)
-        idx_lookups[cls.table_name()] = -np.ones(np.max(table_indices) + 1, dtype=np.int32)
+        idx_lookups[cls.table_name()] = -np.ones(table_indices.max() + 1, dtype=np.int32)
         idx_lookups[cls.table_name()][table_indices] = np.arange(table_len) + current_start
         return end, current_table + 1
 


### PR DESCRIPTION
In some combinations of numpy/pandas, it is not possible to apply np.max on a pandas Int64 Index, see:
https://github.com/numpy/numpy/issues/13285

I am experiencing this with numpy 1.17.4 and pandas 0.24.2. Using pandas .max() function instead should be more stable.