### PR TITLE
Split junction function

### DIFF
--- a/pandapipes/test/test_toolbox.py
+++ b/pandapipes/test/test_toolbox.py
@@ -234,6 +234,11 @@ def test_insert_gap_at_junction():
     assert net.junction_geodata.loc[1, 'x'] == x_1
     assert net.junction_geodata.loc[1, 'y'] == y_1
 
+    # insert without coordinates
+    net = nw.gas_strand_2pipes()
+    del net.junction_geodata
+    nj = pandapipes.insert_gap_at_junction(net, 1, behind=True)
+    assert 'junction_geodata' not in dir(net)
 
 if __name__ == '__main__':
     n = pytest.main(["test_toolbox.py"])

--- a/pandapipes/toolbox.py
+++ b/pandapipes/toolbox.py
@@ -404,16 +404,17 @@ def insert_gap_at_junction(net, junction_idx, behind=True, offset_x=0, offset_y=
     """
     Splits a junctions and inserts a by inserting a second junction at the same position.
 
-    Purpose: prepare to insert a branch component at the given junction later
+    Purpose: split a junction to insert a branch component at the given junction later.
     At the same position as the given junction ('old junction'), a new junction is added to the grid
-    - if given, with a little offset in the coordinates. All attributes are copied.
+    - if given, with a little offset in the coordinates. All attributes are copied, expect for
+    Index.
     From a pipe-perspective, the new junction can be inserted before or behind the old
-    junction. If 'behind=True', the from_node is changed to the new junction for branch elements
+    junction. If 'behind=True', the from_node is changed to the new junction ID for branch elements
     that had the old junction set as from_node. Respectively, if 'behind=False', the to_junction is
     replaced.
     Node elements remain with the old junction.
 
-    :param net: pandapipes net that contains the junction that should be splitted
+    :param net: pandapipes net that contains the junction that should be split
     :type net: pandapipesNet
     :param junction_idx: index of the junction at which the element should be inserted
     :type junction_idx: int
@@ -436,7 +437,7 @@ def insert_gap_at_junction(net, junction_idx, behind=True, offset_x=0, offset_y=
     else:
         x = y = None
     nj = create_junction(net, oj.pn_bar, oj.tfluid_k, oj.height_m, str(oj.name)+"_aux_split",
-                         geodata=(x, y))
+                         type=oj.type, geodata=(x, y))
 
     # adjust connected branch elements:
     if behind:

--- a/pandapipes/toolbox.py
+++ b/pandapipes/toolbox.py
@@ -429,13 +429,13 @@ def insert_gap_at_junction(net, junction_idx, behind=True, offset_x=0, offset_y=
     """
 
     oj = net.junction.loc[junction_idx]   # old junction
-    if net.junction_geodata:
+    if net.junction_geodata is not None:
         x, y = net.junction_geodata.loc[junction_idx]
         x += offset_x
         y += offset_y
     else:
         x = y = None
-    nj = create_junction(net, oj.pn_bar, oj.tfluid_k, oj.height_m, oj.name+"_aux_split",
+    nj = create_junction(net, oj.pn_bar, oj.tfluid_k, oj.height_m, str(oj.name)+"_aux_split",
                          geodata=(x, y))
 
     # adjust connected branch elements:
@@ -448,7 +448,7 @@ def insert_gap_at_junction(net, junction_idx, behind=True, offset_x=0, offset_y=
                    if issubclass(comp, BranchComponent)]
 
     for bc in branch_comp:
-        net[bc][change_junction].loc[net[bc][change_junction] == oj] = nj
+        net[bc][change_junction].loc[net[bc][change_junction] == oj.name] = nj
 
     return nj
 

--- a/pandapipes/toolbox.py
+++ b/pandapipes/toolbox.py
@@ -430,14 +430,13 @@ def insert_gap_at_junction(net, junction_idx, behind=True, offset_x=0, offset_y=
     """
 
     oj = net.junction.loc[junction_idx]   # old junction
-    if net.junction_geodata is not None:
+    if 'junction_geodata' in dir(net) and (len(net.junction_geodata) > 0):
         x, y = net.junction_geodata.loc[junction_idx]
-        x += offset_x
-        y += offset_y
+        coord = (x + offset_x,  y + offset_y)
     else:
-        x = y = None
+        coord = None
     nj = create_junction(net, oj.pn_bar, oj.tfluid_k, oj.height_m, str(oj.name)+"_aux_split",
-                         type=oj.type, geodata=(x, y))
+                         type=oj.type, geodata=coord)
 
     # adjust connected branch elements:
     if behind:


### PR DESCRIPTION
A toolbox function that can be helpful if a new branch element should be inserted into an existing network. It creates a new junction on the same position as the old one that has to be provided; a little offset can be added for differentiation in plots. Then, the from_junctions or to_junctions of all branch elements that were connected to the old junction are changed to the new junction. Node elements remain with the old junction. 

In a second step (not part of this function), a branch component (e.g., pump) has to be inserted between the old junction and the new junction. Otherwise, the junctions are not connected. 

What do you think about? Also, if a better name comes to your mind, I am happy to change it :)