### PR TITLE
add H2 as one default fluid in doc and tutorials, fall back option in add_fluid

### DIFF
--- a/doc/source/fluid_properties/create_fluids.rst
+++ b/doc/source/fluid_properties/create_fluids.rst
@@ -11,7 +11,7 @@ Fluid from Library
 
 In the fluid library some default fluids are already implemented. Currently it is
 possible to work with the default fluids high and low calorific natural
-gas (hgas and lgas), water and air.
+gas (hgas and lgas), hydrogen, water and air.
 One of these default fluids can be created and added to an
 existing network by calling the following function.
 

--- a/doc/source/fluid_properties/fluids.rst
+++ b/doc/source/fluid_properties/fluids.rst
@@ -5,8 +5,7 @@ Fluid Properties in pandapipes
 The pipelines in the pandapipes network are run with a certain fluid. This can be
 chosen individually for the net from the fluid library or by own creation. The fluids
 are defined by certain properties. In the fluid library currently high and low calorific natural
-gas (hgas and lgas), water and air.
-are implemented with default properties.
+gas (hgas and lgas), hydrogen, water and air are implemented with default properties.
 
 
 The Fluid Class

--- a/pandapipes/create.py
+++ b/pandapipes/create.py
@@ -922,7 +922,7 @@ def create_circ_pump_const_mass_flow(net, from_junction, to_junction, p_bar, mdo
 def create_fluid_from_lib(net, name, overwrite=True):
     """
     Creates a fluid from library (if there is an entry) and sets net["fluid"] to this value.
-    Currently existing fluids in the library are: "hgas", "lgas", "water", "air".
+    Currently existing fluids in the library are: "hgas", "lgas", "hydrogen", "water", "air".
 
     :param net: The net for which this fluid should be created
     :type net: pandapipesNet

--- a/pandapipes/create.py
+++ b/pandapipes/create.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 from pandapipes.component_models.auxiliaries.component_toolbox import add_new_component
 from pandapipes.pandapipes_net import pandapipesNet, get_default_pandapipes_structure
-from pandapipes.properties import call_lib, add_fluid_to_net
+from pandapipes.properties import call_lib
+from pandapipes.properties.fluids import _add_fluid_to_net
 from pandapower.auxiliary import get_free_id, _preserve_dtypes
 from pandapipes.properties.fluids import Fluid
 from pandapipes.std_types.std_type import PumpStdType, add_basic_std_types, add_pump_std_type, \
@@ -936,4 +937,4 @@ def create_fluid_from_lib(net, name, overwrite=True):
         >>> pp.create_fluid_from_lib(net, name="water")
 
     """
-    add_fluid_to_net(net, call_lib(name), overwrite=overwrite)
+    _add_fluid_to_net(net, call_lib(name), overwrite=overwrite)

--- a/pandapipes/properties/fluids.py
+++ b/pandapipes/properties/fluids.py
@@ -484,7 +484,7 @@ def get_fluid(net):
     return fluid
 
 
-def add_fluid_to_net(net, fluid, overwrite=True):
+def _add_fluid_to_net(net, fluid, overwrite=True):
     """
     Adds a fluid to a net. If overwrite is False, a warning is printed and the fluid is not set.
 
@@ -505,6 +505,8 @@ def add_fluid_to_net(net, fluid, overwrite=True):
         return
 
     if isinstance(fluid, str):
+        logger.warning("Instead of a pandapipes.Fluid, a string ('%s') was passed to the fluid "
+                       "argument. Internally, it will be passed to call_lib(fluid) to get the "
+                       "respective pandapipes.Fluid." %fluid)
         fluid = call_lib(fluid)
-
     net["fluid"] = fluid

--- a/pandapipes/properties/fluids.py
+++ b/pandapipes/properties/fluids.py
@@ -501,7 +501,10 @@ def add_fluid_to_net(net, fluid, overwrite=True):
         fluid_msg = "an existing fluid" if not hasattr(net["fluid"], "name") \
             else "the fluid %s" % net["fluid"].name
         logger.warning("The fluid %s would replace %s and thus cannot be created. Try to set "
-                       "overwrite to False" % (fluid.name, fluid_msg))
+                       "overwrite to True" % (fluid.name, fluid_msg))
         return
+
+    if isinstance(fluid, str):
+        fluid = call_lib(fluid)
 
     net["fluid"] = fluid

--- a/pandapipes/test/api/test_components/test_pipe_results.py
+++ b/pandapipes/test/api/test_components/test_pipe_results.py
@@ -7,6 +7,7 @@ import os
 import numpy as np
 import pandas as pd
 from pandapipes.test.pipeflow_internals import internals_data_path
+from pandapipes.properties.fluids import _add_fluid_to_net
 
 
 def test_pipe_velocity_results():
@@ -32,7 +33,7 @@ def test_pipe_velocity_results():
     pandapipes.create_ext_grid(net, 0, p_bar=51 - 1.01325, t_k=285.15, type="pt")
     pandapipes.create_sink(net, 2, mdot_kg_per_s=0.82752 * 45000 / 3600 / 3)
     pandapipes.create_sink(net, 3, mdot_kg_per_s=0.82752 * 45000 / 3600 / 2)
-    pandapipes.add_fluid_to_net(net, pandapipes.create_constant_fluid(
+    _add_fluid_to_net(net, pandapipes.create_constant_fluid(
         name="natural_gas", fluid_type="gas", viscosity=11.93e-6, heat_capacity=2185,
         compressibility=1, der_compressibility=0, density=0.82752
     ))
@@ -55,7 +56,7 @@ def test_pipe_velocity_results():
     pandapipes.create_ext_grid(net, 0, p_bar=51 - 1.01325, t_k=285.15, type="pt")
     pandapipes.create_sink(net, 2, mdot_kg_per_s=0.82752 * 45000 / 3600 / 3)
     pandapipes.create_sink(net, 3, mdot_kg_per_s=0.82752 * 45000 / 3600 / 2)
-    pandapipes.add_fluid_to_net(net, pandapipes.create_constant_fluid(
+    _add_fluid_to_net(net, pandapipes.create_constant_fluid(
         name="natural_gas", fluid_type="gas", viscosity=11.93e-6, heat_capacity=2185,
         compressibility=1, der_compressibility=0, density=0.82752
     ))

--- a/pandapipes/test/pipeflow_internals/test_pipeflow_analytic_comparison.py
+++ b/pandapipes/test/pipeflow_internals/test_pipeflow_analytic_comparison.py
@@ -12,7 +12,7 @@ from pandapipes.component_models import Pipe, Junction
 from pandapipes.idx_node import PINIT, TINIT
 from pandapipes.pipeflow_setup import get_lookup
 from pandapipes.test.pipeflow_internals import internals_data_path
-
+from pandapipes.properties.fluids import _add_fluid_to_net
 
 def test_gas_internal_nodes():
     """
@@ -27,7 +27,7 @@ def test_gas_internal_nodes():
     pandapipes.create_pipe_from_parameters(net, 0, 1, 12.0, d, k_mm=.5, sections=12)
     pandapipes.create_ext_grid(net, 0, p_bar=51 - 1.01325, t_k=285.15, type="pt")
     pandapipes.create_sink(net, 1, mdot_kg_per_s=0.82752 * 45000 / 3600)
-    pandapipes.add_fluid_to_net(net, pandapipes.create_constant_fluid(
+    _add_fluid_to_net(net, pandapipes.create_constant_fluid(
         name="natural_gas", fluid_type="gas", viscosity=11.93e-6, heat_capacity=2185,
         compressibility=1, der_compressibility=0, density=0.82752
     ))

--- a/pandapipes/test/properties/test_fluid_specials.py
+++ b/pandapipes/test/properties/test_fluid_specials.py
@@ -4,6 +4,7 @@
 
 import pytest
 import pandapipes
+from pandapipes.properties.fluids import _add_fluid_to_net
 
 
 def test_add_fluid():
@@ -16,21 +17,21 @@ def test_add_fluid():
     except UserWarning:
         pass
 
-    pandapipes.add_fluid_to_net(net, fluid_old)
+    _add_fluid_to_net(net, fluid_old)
     fluid_new = pandapipes.create_constant_fluid("arbitrary_gas2", "gas", density=2,
                                                  compressibility=2)
-    pandapipes.add_fluid_to_net(net, fluid_new, overwrite=False)
+    _add_fluid_to_net(net, fluid_new, overwrite=False)
     assert pandapipes.get_fluid(net) == fluid_old
 
-    pandapipes.add_fluid_to_net(net, fluid_new)
+    _add_fluid_to_net(net, fluid_new)
     assert pandapipes.get_fluid(net) == fluid_new
 
     net["fluid"] = "Hello"
 
-    pandapipes.add_fluid_to_net(net, fluid_new, overwrite=False)
+    _add_fluid_to_net(net, fluid_new, overwrite=False)
     assert pandapipes.get_fluid(net) == "Hello"
 
-    pandapipes.add_fluid_to_net(net, fluid_new)
+    _add_fluid_to_net(net, fluid_new)
     assert pandapipes.get_fluid(net) == fluid_new
 
 

--- a/tutorials/creating_a_simple_network.ipynb
+++ b/tutorials/creating_a_simple_network.ipynb
@@ -33,7 +33,11 @@
    "metadata": {},
    "source": [
     "First, we import pandapipes and create an empty network:\n",
-    "We have to state the name of the fluid for the network. In pandapipes, some fluids are already pre-defined, e.g. <span style=\"color:green\">hgas</span>, <span style=\"color:green\">lgas</span> (high and low calorific natural gas), <span style=\"color:green\">water</span>, and <span style=\"color:green\">air</span>, but you can also create your own fluid if you prefer (tutorial in preparation). \n",
+    "We have to state the name of the fluid for the network. In pandapipes, some fluids are already\n",
+    "pre-defined, e.g. <span style=\"color:green\">hgas</span>, <span style=\"color:green\">lgas</span>\n",
+    "(high and low calorific natural gas),  <span style=\"color:green\">hydrogen</span>,\n",
+    "<span style=\"color:green\">water</span>, and <span style=\"color:green\">air</span>, but you can\n",
+    "also create your own fluid if you prefer (tutorial in preparation).\n",
     "\n",
     "In this example, we will create a medium pressure gas network and choose <span style=\"color:green\">lgas</span> from the predefined fluids in pandapipes."
    ]

--- a/tutorials/minimal_example.ipynb
+++ b/tutorials/minimal_example.ipynb
@@ -44,9 +44,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the fluid used here is lgas. You can find 4 predefined fluids in pandapipes:\n",
+    "Note that the fluid used here is lgas. You can find 5 predefined fluids in pandapipes:\n",
     "    - lgas\n",
     "    - hgas\n",
+    "    - hydrogen\n",
     "    - water\n",
     "    - air\n",
     "\n",
@@ -220,15 +221,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
   }
  },
  "nbformat": 4,

--- a/tutorials/simple_plot.ipynb
+++ b/tutorials/simple_plot.ipynb
@@ -28,7 +28,8 @@
     "The simple plot function allows you to plot networks to get a fast visualisation. There is no need to gain a deep \n",
     "understanding of the plotting module.\n",
     "\n",
-    "First of all, a simple network with genuine geodata is created. To get a better understanding of creating networks, follow the Creating a simple network tutorial. "
+    "First of all, a simple network with genuine geodata is created. To get a better understanding of\n",
+    "creating networks, follow the [Creating a simple network](https://github.com/e2nIEE/pandapipes/blob/develop/tutorials/creating_a_simple_network.ipynb) tutorial."
    ]
   },
   {
@@ -227,15 +228,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.4"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
   }
  },
  "nbformat": 4,

--- a/tutorials/simple_time_series_example.ipynb
+++ b/tutorials/simple_time_series_example.ipynb
@@ -28,10 +28,9 @@
     "import os\n",
     "import pandas as pd\n",
     "import pandapower.control as control\n",
-    "import pandapipes\n",
     "from pandapower.timeseries import DFData\n",
     "from pandapower.timeseries import OutputWriter\n",
-    "from pandapipes.timeseries import run_timeseries_ppipe"
+    "from pandapipes.timeseries import run_timeseries"
    ]
   },
   {
@@ -63,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "net = pandapipes.networks.simple_gas_networks.gas_meshed_delta()"
+    "net = networks.simple_gas_networks.gas_meshed_delta()"
    ]
   },
   {
@@ -178,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_timeseries_ppipe(net, time_steps, output_writer=ow)"
+    "run_timeseries(net, time_steps, output_writer=ow)"
    ]
   },
   {
@@ -197,14 +196,13 @@
     "import os\n",
     "import pandas as pd\n",
     "import pandapower.control as control\n",
-    "import pandapipes\n",
     "from pandapower.timeseries import DFData\n",
     "from pandapower.timeseries import OutputWriter\n",
-    "from pandapipes.timeseries import run_timeseries_ppipe\n",
+    "from pandapipes.timeseries import run_timeseries\n",
     "from pandapipes import networks\n",
     "\n",
     "# 1. create/ load the pandapipes network\n",
-    "net = pandapipes.networks.simple_gas_networks.gas_meshed_delta()\n",
+    "net = networks.simple_gas_networks.gas_meshed_delta()\n",
     "\n",
     "# 2. preparing the network for simulation\n",
     "profiles_sink = pd.read_csv(os.path.join('files',\n",
@@ -239,7 +237,7 @@
     "ow = OutputWriter(net, time_steps, output_path=None, log_variables=log_variables)\n",
     "\n",
     "# 5. run simulation\n",
-    "run_timeseries_ppipe(net, time_steps, output_writer=ow)"
+    "run_timeseries(net, time_steps, output_writer=ow)"
    ]
   },
   {


### PR DESCRIPTION

* Hydrogen is now an additional default fluid and has been added to the text in the tutorials and documentation.
* if someone passed a string to add_fluid_to_net(net, fluid_as_string), it would write the string to the net. A call_lib intermediate step has been added.
* import of run_timeseries in the time series tutorial fixed
