### PR TITLE
register the 'slow' marker in pytests

### DIFF
--- a/pandapipes/test/pytest.ini
+++ b/pandapipes/test/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    slow: mark tests which are slow
+;filterwarnings =
+;    ignore: the matrix subclass:PendingDeprecationWarning


### PR DESCRIPTION
otherwise, a warning would be raised