### PR TITLE
Add Python 3.10 to GHA testing matrix

### DIFF
--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,16 @@
 Change Log
 =============
 
+[upcoming release] - 2022-..-..
+-------------------------------
+- [ADDED] automated test with Python 3.10 added to GitHub Actions CI (now Python 3.7 - 3.10)
+
 [0.6.0] - 2022-02-07
 -------------------------------
-- [ADDED] Adding pressure controler as new component
+- [ADDED] Adding pressure controller as new component
 - [ADDED] Adding compressor as new component
 - [ADDED] Compressing power of a pump component are returned as result
-- [ADDED] Adding polynominal fluids
+- [ADDED] Adding polynomial fluids
 - [CHANGED] Removing irrelevant results in branch models with zero length (mean velocity, lambda, reynolds)
 - [FIXED] Only ext grids in service are considered
 - [FIXED] Converting format of the nets in a multinet correctly


### PR DESCRIPTION
* all tests pass with Python 3.10 so we should include it in the CI