### PR TITLE
add new tqdm progress bar to multinet time series

### DIFF
--- a/pandapipes/multinet/timeseries/run_time_series_multinet.py
+++ b/pandapipes/multinet/timeseries/run_time_series_multinet.py
@@ -9,6 +9,7 @@ from pandapower import pandapowerNet
 from pandapower.control.util.diagnostic import control_diagnostic
 from pandapower.timeseries.run_time_series import get_recycle_settings, init_time_steps, output_writer_routine, \
     print_progress_bar, cleanup, run_loop, init_default_outputwriter as init_default_ow_pp, init_output_writer
+import tqdm
 
 try:
     import pplog
@@ -91,7 +92,7 @@ def init_time_series(multinet, time_steps, continue_on_divergence=False, verbose
 
     if logger.level != 10 and verbose:
         # simple progress bar
-        print_progress_bar(0, len(time_steps), prefix='Progress:', suffix='Complete', length=50)
+        ts_variables['progress_bar'] = tqdm.tqdm(total=len(time_steps))
 
     return ts_variables
 


### PR DESCRIPTION
* according to changes in [pandapower PR #1457](https://github.com/e2nIEE/pandapower/pull/1457)
* this change is neccessary because test_time_series_p2g_control will fail when pandapower PR 1457 is merged
* the new import tqdm will be covered by pandapower PR #1457 which adds tqdm to the pandapower dependencies
* this PR should not be merged before pandapower PR #1457 is merged