### PR TITLE
increase required pandapower to version 2.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
 	long_description_content_type='text/x-rst',
     url='http://www.pandapipes.org',
     license='BSD',
-    install_requires=["pandapower>=2.8.0", "matplotlib"],
+    install_requires=["pandapower>=2.9.0", "matplotlib"],
     extras_require={"docs": ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex"],
                     "plotting": ["plotly", "python-igraph"],
                     "test": ["pytest", "pytest-xdist"],


### PR DESCRIPTION
* this is necessary to get the tqdm package indirectly, as a dependency of pandapower