### PR TITLE
enable using "run" parameter for run_control for multinet

### DIFF
--- a/pandapipes/multinet/control/run_control_multinet.py
+++ b/pandapipes/multinet/control/run_control_multinet.py
@@ -228,8 +228,7 @@ def prepare_run_ctrl(multinet, ctrl_variables, **kwargs):
             net_names = c.object.get_all_net_names()
             for net_name in net_names:
                 if net_name not in ctrl_variables.keys():
-                    ctrl_variables[net_name] = {'run': None, 'initial_run': None,
-                                                'continue_on_divergence': None, 'errors': ()}
+                    ctrl_variables[net_name] = {}
                 net = multinet['nets'][net_name]
                 if isinstance(net, ppipes.pandapipesNet):
                     ctrl_variables_net = prepare_run_ctrl_ppipes(net, None, **kwargs)
@@ -238,16 +237,13 @@ def prepare_run_ctrl(multinet, ctrl_variables, **kwargs):
                 else:
                     raise ValueError('the given nets are neither pandapipes nor pandapower nets')
 
-                ctrl_variables[net_name]['run'] = ctrl_variables_net['run']
-                ctrl_variables[net_name]['errors'] = ctrl_variables_net['errors']
-                ctrl_variables[net_name]['initial_run'] = ctrl_variables[net_name]['initial_run'] if \
-                    ctrl_variables[net_name]['initial_run'] is not None else ctrl_variables_net['initial_run']
+                ctrl_variables[net_name]['run'] = ctrl_variables[net_name].get("run", ctrl_variables_net['run'])
+                ctrl_variables[net_name]['errors'] = ctrl_variables[net_name].get("errors", ctrl_variables_net['errors'])
+                ctrl_variables[net_name]['initial_run'] = ctrl_variables[net_name].get('initial_run', ctrl_variables_net['initial_run'])
                 ctrl_variables[net_name]['only_v_results'], ctrl_variables[net_name]['recycle'] = \
                     get_recycle(ctrl_variables_net)
                 ctrl_variables[net_name]['continue_on_divergence'] = \
-                    ctrl_variables[net_name]['continue_on_divergence'] if \
-                    ctrl_variables[net_name]['continue_on_divergence'] is not None else \
-                    ctrl_variables_net['continue_on_divergence']
+                    ctrl_variables[net_name].get('continue_on_divergence', ctrl_variables_net['continue_on_divergence'])
                 excl_net += [net_name]
 
     for net_name in multinet['nets'].keys():

--- a/pandapipes/multinet/timeseries/run_time_series_multinet.py
+++ b/pandapipes/multinet/timeseries/run_time_series_multinet.py
@@ -79,7 +79,7 @@ def init_time_series(multinet, time_steps, continue_on_divergence=False, verbose
         if hasattr(run, "__name__") and run.__name__ == "runpp":
             # use faster runpp options if possible
             recycle_options = get_recycle_settings(net, **kwargs)
-        ts_variables[net_name]['run'] = run['net_name'] if run is not None else ts_variables[net_name]['run']
+        ts_variables[net_name]['run'] = run[net_name] if run is not None else ts_variables[net_name]['run']
         ts_variables[net_name]['recycle_options'] = recycle_options
         init_output_writer(net, time_steps)
 


### PR DESCRIPTION
for run_control, one can pass "run" parameter to specify the function (e.g. pp.runpp, pp.rundcpp, pp.runopf, etc.).

For multinet, it becomes a dictionary with net names as keys and functions as values:

run={"power_net": pp.runpp, "power_net_dc": pp.rundcpp, "gas_net": ppipes.pipeflow}

Also, rearranged code to make it more compact by using .get for dictionaries