### PR TITLE
removed type hints in numba jit signatures to avoid problems

### DIFF
--- a/pandapipes/pf/internals_toolbox.py
+++ b/pandapipes/pf/internals_toolbox.py
@@ -6,15 +6,9 @@ import numpy as np
 import logging
 try:
     from numba import jit
-    from numba import int32, float64, int64
-    from numba.core.types.scalars import Integer
-    from numba.core.types.containers import Tuple
-    from numba import typeof
     numba_installed = True
 except ImportError:
     from pandapower.pf.no_numba import jit
-    from numpy import int32, float64, int64, int as Integer
-    from builtins import tuple as Tuple
     numba_installed = False
 
 
@@ -143,7 +137,7 @@ def select_from_pit(table_index_array, input_array, data):
     return data[indices]
 
 
-@jit((int32[:], float64[:, :], int32, int64, int64), nopython=True)
+@jit(nopython=True)
 def _sum_values_by_index(indices, value_arr, max_ind, le, n_vals):
     ind1 = indices + 1
     new_indices = np.zeros(max_ind + 2, dtype=np.int32)
@@ -157,6 +151,6 @@ def _sum_values_by_index(indices, value_arr, max_ind, le, n_vals):
     return new_indices, summed_values
 
 
-@jit(int64(int32[:]), nopython=True)
+@jit(nopython=True)
 def max_nb(arr):
     return np.max(arr)


### PR DESCRIPTION
no significant speedup possible really