### PR TITLE
added s to hydraulic in pipeflow example

### DIFF
--- a/pandapipes/pipeflow.py
+++ b/pandapipes/pipeflow.py
@@ -54,7 +54,7 @@ def pipeflow(net, sol_vec=None, **kwargs):
     :return: No output
 
     :Example:
-        >>> pipeflow(net, mode="hydraulic")
+        >>> pipeflow(net, mode="hydraulics")
 
     """
     local_params = dict(locals())


### PR DESCRIPTION
In der Dok von der Funktion pipeflow hat ein s bei mode "hydraulics" gefehlt. Habe es hinzugefügt.