### PR TITLE
Load JSON string simplified

### DIFF
--- a/pandapipes/io/file_io.py
+++ b/pandapipes/io/file_io.py
@@ -150,8 +150,7 @@ def from_json_string(json_string, convert=False, encryption_key=None):
     if encryption_key is not None:
         json_string = decrypt_string(json_string, encryption_key)
 
-    net = json.loads(json_string, cls=PPJSONDecoder,
-                     object_hook=partial(pp_hook, registry_class=FromSerializableRegistryPpipe))
+    net = json.loads(json_string, cls=PPJSONDecoder, registry_class=FromSerializableRegistryPpipe)
 
     if convert and isinstance(net, pandapipesNet):
         convert_format(net)


### PR DESCRIPTION
In file_io: do not pass object_hook to JSON Decoder in json.loads, but registry_class.

Please do not merge before pandapower has been updated to process this change! (cf. e2nIEE/pandapower#1827)