### PR TITLE
replaced references to python-igraph as recommended in #547

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest python-igraph pytest-split numba
+          python -m pip install pytest igraph pytest-split numba
       - name: Install pandapipes from TestPyPI
         if: ${{ inputs.upload_server == 'testpypi'}}
         run: |

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest python-igraph pytest-split numba
+          python -m pip install pytest igraph pytest-split numba
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if ${{ matrix.python-version == '3.7' }}; 
           then pip install pandapower==2.11.1; 
@@ -100,7 +100,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest nbmake pytest-xdist pytest-split python-igraph numba 
+          python -m pip install pytest nbmake pytest-xdist pytest-split igraph numba 
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if ${{ matrix.python-version == '3.7' }}; 
           then pip install pandapower==2.11.1; 

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest python-igraph pytest-split numba
+          python -m pip install pytest igraph pytest-split numba
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if ${{ matrix.python-version == '3.7' }}; 
           then pip install pandapower==2.11.1; 
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest nbmake pytest-xdist pytest-split python-igraph numba 
+          python -m pip install pytest nbmake pytest-xdist pytest-split igraph numba 
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           if ${{ matrix.python-version == '3.7' }}; 
           then pip install pandapower==2.11.1; 

--- a/pandapipes/plotting/generic_geodata.py
+++ b/pandapipes/plotting/generic_geodata.py
@@ -39,9 +39,9 @@ def build_igraph_from_ppipes(net, junctions=None):
     try:
         import igraph as ig
     except (DeprecationWarning, ImportError):
-        raise ImportError("Please install python-igraph with "
-                          "`pip install python-igraph` or "
-                          "`conda install python-igraph` "
+        raise ImportError("Please install igraph with "
+                          "`pip install igraph` or "
+                          "`conda install igraph` "
                           "or from https://www.lfd.uci.edu/~gohlke/pythonlibs")
     g = ig.Graph(directed=True)
     junction_index = net.junction.index if junctions is None else np.array(junctions)

--- a/pandapipes/test/plotting/test_generic_coordinates.py
+++ b/pandapipes/test/plotting/test_generic_coordinates.py
@@ -15,7 +15,7 @@ except ImportError:
     IGRAPH_INSTALLED = False
 
 
-@pytest.mark.skipif(IGRAPH_INSTALLED is False, reason="Requires python-igraph.")
+@pytest.mark.skipif(IGRAPH_INSTALLED is False, reason="Requires igraph.")
 def test_create_generic_coordinates_igraph(base_net_is_with_pumps):
     net = copy.deepcopy(base_net_is_with_pumps)
     net.junction_geodata.drop(net.junction_geodata.index, inplace=True)

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ setup(
     license='BSD',
     install_requires=["pandapower>=2.11.1", "matplotlib", "shapely"],
     extras_require={"docs": ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex"],
-                    "plotting": ["plotly", "python-igraph"],
+                    "plotting": ["plotly", "igraph"],
                     "test": ["pytest", "pytest-xdist", "nbmake"],
                     "all": ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-                            "plotly", "python-igraph", "pytest", "pytest-xdist", "nbmake"]},
+                            "plotly", "igraph", "pytest", "pytest-xdist", "nbmake"]},
     packages=find_packages(),
     include_package_data=True,
     classifiers=classifiers


### PR DESCRIPTION
closes #547

@jkisse I would like to add this change to the hotfix, just to have it fixed.