### PR TITLE
internal component arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 - [CHANGED] dropped support for Python 3.7 (no longer included in test pipeline)
 - [CHANGED] connectivity check now separated by hydraulics and heat_transfer calculation, so that also results can differ in some rows (NaN or not)
 - [CHANGED] dynamic creation of lookups for getting pit as pandas tables
+- [CHANGED] components can have their own internal arrays for specific calculations (e.g. for compressor pressure ratio), so that the pit does not need to include such component specific entries
 - [FIXED] in STANET converter: bug fix for heat exchanger creation and external temperatures of pipes added
 - [REMOVED] broken travis badge removed from readme
 

--- a/pandapipes/component_models/abstract_models/base_component.py
+++ b/pandapipes/component_models/abstract_models/base_component.py
@@ -126,6 +126,21 @@ class Component:
         return current_start, current_table
 
     @classmethod
+    def create_component_array(cls, net, component_pits):
+        """
+        Function which creates an internal array of the component in analogy to the pit, but with
+        component specific entries, that are not needed in the pit.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param component_pits: dictionary of component specific arrays
+        :type component_pits: dict
+        :return:
+        :rtype:
+        """
+        pass
+
+    @classmethod
     def create_pit_node_entries(cls, net, node_pit):
         """
         Function which creates pit branch entries.

--- a/pandapipes/component_models/component_toolbox.py
+++ b/pandapipes/component_models/component_toolbox.py
@@ -198,3 +198,23 @@ def standard_branch_wo_internals_result_lookup(net):
         required_results_hyd.extend([("v_mean_m_per_s", "v_mps")])
 
     return required_results_hyd, required_results_ht
+
+
+def get_component_array(net, component_name, internal=True):
+    """
+    Returns the internal array of a component.
+
+    :param net: The pandapipes network
+    :type net: pandapipesNet
+    :param component_name: Table name of the component for which to extract internal array
+    :type component_name: str
+    :param internal: If True, only return entries of active elements (included in _active_pit)
+    :type internal: bool
+    :return: component_array - internal array of the component
+    :rtype: numpy.ndarray
+    """
+    f_all, t_all = get_lookup(net, "branch", "from_to")[component_name]
+    if not internal:
+        return net["_pit"]["components"][component_name]
+    in_service_elm = get_lookup(net, "branch", "active_hydraulics")[f_all:t_all]
+    return net["_pit"]["components"][component_name][in_service_elm]

--- a/pandapipes/component_models/component_toolbox.py
+++ b/pandapipes/component_models/component_toolbox.py
@@ -200,7 +200,7 @@ def standard_branch_wo_internals_result_lookup(net):
     return required_results_hyd, required_results_ht
 
 
-def get_component_array(net, component_name, internal=True):
+def get_component_array(net, component_name, component_type="branch", only_active=True):
     """
     Returns the internal array of a component.
 
@@ -208,13 +208,15 @@ def get_component_array(net, component_name, internal=True):
     :type net: pandapipesNet
     :param component_name: Table name of the component for which to extract internal array
     :type component_name: str
-    :param internal: If True, only return entries of active elements (included in _active_pit)
-    :type internal: bool
+    :param component_type: Type of component that is considered ("branch" or "node")
+    :type component_type: str, default "branch"
+    :param only_active: If True, only return entries of active elements (included in _active_pit)
+    :type only_active: bool
     :return: component_array - internal array of the component
     :rtype: numpy.ndarray
     """
-    f_all, t_all = get_lookup(net, "branch", "from_to")[component_name]
-    if not internal:
+    f_all, t_all = get_lookup(net, component_type, "from_to")[component_name]
+    if not only_active:
         return net["_pit"]["components"][component_name]
-    in_service_elm = get_lookup(net, "branch", "active_hydraulics")[f_all:t_all]
+    in_service_elm = get_lookup(net, component_type, "active_hydraulics")[f_all:t_all]
     return net["_pit"]["components"][component_name][in_service_elm]

--- a/pandapipes/component_models/compressor_component.py
+++ b/pandapipes/component_models/compressor_component.py
@@ -5,10 +5,10 @@
 import numpy as np
 from numpy import dtype
 
+from pandapipes.component_models.component_toolbox import get_component_array
 from pandapipes.component_models.junction_component import Junction
 from pandapipes.component_models.pump_component import Pump
-from pandapipes.idx_branch import VINIT, D, AREA, LOSS_COEFFICIENT as LC, FROM_NODE, PL,\
-    PRESSURE_RATIO
+from pandapipes.idx_branch import VINIT, D, AREA, LOSS_COEFFICIENT as LC, FROM_NODE, PL
 from pandapipes.idx_node import PINIT, PAMB
 
 
@@ -16,6 +16,9 @@ class Compressor(Pump):
     """
 
     """
+    PRESSURE_RATIO = 0
+
+    internal_cols = 1
 
     @classmethod
     def table_name(cls):
@@ -41,23 +44,42 @@ class Compressor(Pump):
         compressor_pit[:, D] = 0.1
         compressor_pit[:, AREA] = compressor_pit[:, D] ** 2 * np.pi / 4
         compressor_pit[:, LC] = 0
-        compressor_pit[:, PRESSURE_RATIO] = net[cls.table_name()].pressure_ratio.values
+
+    @classmethod
+    def create_component_array(cls, net, component_pits):
+        """
+        Function which creates an internal array of the component in analogy to the pit, but with
+        component specific entries, that are not needed in the pit.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param component_pits: dictionary of component specific arrays
+        :type component_pits: dict
+        :return:
+        :rtype:
+        """
+        tbl = net[cls.table_name()]
+        compr_array = np.zeros(shape=(len(tbl), cls.internal_cols), dtype=np.float64)
+        compr_array[:, cls.PRESSURE_RATIO] = net[cls.table_name()].pressure_ratio.values
+        component_pits[cls.table_name()] = compr_array
 
     @classmethod
     def adaption_before_derivatives_hydraulic(cls, net, branch_pit, node_pit, idx_lookups, options):
         # calculation of pressure lift
         f, t = idx_lookups[cls.table_name()]
-        compressor_pit = branch_pit[f:t, :]
+        compressor_branch_pit = branch_pit[f:t, :]
+        compressor_array = get_component_array(net, cls.table_name())
 
-        from_nodes = compressor_pit[:, FROM_NODE].astype(np.int32)
+        from_nodes = compressor_branch_pit[:, FROM_NODE].astype(np.int32)
         p_from = node_pit[from_nodes, PAMB] + node_pit[from_nodes, PINIT]
-        p_to_calc = p_from * compressor_pit[:, PRESSURE_RATIO]
+
+        p_to_calc = p_from * compressor_array[:, cls.PRESSURE_RATIO]
         pl_abs = p_to_calc - p_from
 
-        v_mps = compressor_pit[:, VINIT]
+        v_mps = compressor_branch_pit[:, VINIT]
         pl_abs[v_mps < 0] = 0  # force pressure lift = 0 for reverse flow
 
-        compressor_pit[:, PL] = pl_abs
+        compressor_branch_pit[:, PL] = pl_abs
 
     @classmethod
     def get_component_input(cls):

--- a/pandapipes/component_models/pump_component.py
+++ b/pandapipes/component_models/pump_component.py
@@ -7,12 +7,12 @@ from operator import itemgetter
 import numpy as np
 from numpy import dtype
 
-from pandapipes.component_models.junction_component import Junction
 from pandapipes.component_models.abstract_models.branch_wzerolength_models import \
     BranchWZeroLengthComponent
+from pandapipes.component_models.component_toolbox import get_component_array
+from pandapipes.component_models.junction_component import Junction
 from pandapipes.constants import NORMAL_TEMPERATURE, NORMAL_PRESSURE, R_UNIVERSAL, P_CONVERSION
-from pandapipes.idx_branch import STD_TYPE, VINIT, D, AREA, TL, LOSS_COEFFICIENT as LC, FROM_NODE, \
-    TINIT, PL
+from pandapipes.idx_branch import VINIT, D, AREA, TL, LOSS_COEFFICIENT as LC, FROM_NODE, TINIT, PL
 from pandapipes.idx_node import PINIT, PAMB, TINIT as TINIT_NODE
 from pandapipes.pf.pipeflow_setup import get_fluid, get_net_option, get_lookup
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
@@ -29,6 +29,9 @@ class Pump(BranchWZeroLengthComponent):
     """
 
     """
+    STD_TYPE = 0
+
+    internal_cols = 1
 
     @classmethod
     def from_to_node_cols(cls):
@@ -58,29 +61,49 @@ class Pump(BranchWZeroLengthComponent):
         :return: No Output.
         """
         pump_pit = super().create_pit_branch_entries(net, branch_pit)
-        std_types_lookup = np.array(list(net.std_types[cls.table_name()].keys()))
-        std_type, pos = np.where(net[cls.table_name()]['std_type'].values
-                                 == std_types_lookup[:, np.newaxis])
-        pump_pit[pos, STD_TYPE] = std_type
         pump_pit[:, D] = 0.1
         pump_pit[:, AREA] = pump_pit[:, D] ** 2 * np.pi / 4
         pump_pit[:, LC] = 0
 
     @classmethod
+    def create_component_array(cls, net, component_pits):
+        """
+        Function which creates an internal array of the component in analogy to the pit, but with
+        component specific entries, that are not needed in the pit.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param component_pits: dictionary of component specific arrays
+        :type component_pits: dict
+        :return:
+        :rtype:
+        """
+        tbl = net[cls.table_name()]
+        pump_array = np.zeros(shape=(len(tbl), cls.internal_cols), dtype=np.float64)
+        std_types_lookup = get_std_type_lookup(net, cls.table_name())
+        std_type, pos = np.where(net[cls.table_name()]['std_type'].values
+                                 == std_types_lookup[:, np.newaxis])
+        pump_array[pos, cls.STD_TYPE] = std_type
+        component_pits[cls.table_name()] = pump_array
+
+    @classmethod
     def adaption_before_derivatives_hydraulic(cls, net, branch_pit, node_pit, idx_lookups, options):
         # calculation of pressure lift
         f, t = idx_lookups[cls.table_name()]
-        pump_pit = branch_pit[f:t, :]
-        area = pump_pit[:, AREA]
-        idx = pump_pit[:, STD_TYPE].astype(int)
-        std_types = np.array(list(net.std_types['pump'].keys()))[idx]
-        from_nodes = pump_pit[:, FROM_NODE].astype(np.int32)
-        # to_nodes = pump_pit[:, TO_NODE].astype(np.int32)
+        pump_branch_pit = branch_pit[f:t, :]
+        area = pump_branch_pit[:, AREA]
+
+        pump_array = get_component_array(net, cls.table_name())
+        idx = pump_array[:, cls.STD_TYPE].astype(np.int32)
+        std_types = get_std_type_lookup(net, cls.table_name())[idx]
+
+        from_nodes = pump_branch_pit[:, FROM_NODE].astype(np.int32)
+        # to_nodes = pump_branch_pit[:, TO_NODE].astype(np.int32)
         fluid = get_fluid(net)
         p_from = node_pit[from_nodes, PAMB] + node_pit[from_nodes, PINIT]
         # p_to = node_pit[to_nodes, PAMB] + node_pit[to_nodes, PINIT]
-        numerator = NORMAL_PRESSURE * pump_pit[:, TINIT]
-        v_mps = pump_pit[:, VINIT]
+        numerator = NORMAL_PRESSURE * pump_branch_pit[:, TINIT]
+        v_mps = pump_branch_pit[:, VINIT]
         if fluid.is_gas:
             # consider volume flow at inlet
             normfactor_from = numerator * fluid.get_property("compressibility", p_from) \
@@ -93,7 +116,7 @@ class Pump(BranchWZeroLengthComponent):
             fcts = itemgetter(*std_types)(net['std_types']['pump'])
             fcts = [fcts] if not isinstance(fcts, tuple) else fcts
             pl = np.array(list(map(lambda x, y: x.get_pressure(y), fcts, vol)))
-            pump_pit[:, PL] = pl
+            pump_branch_pit[:, PL] = pl
 
     @classmethod
     def calculate_temperature_lift(cls, net, branch_component_pit, node_pit):
@@ -220,3 +243,7 @@ class Pump(BranchWZeroLengthComponent):
             output += ["compr_power_mw"]
 
         return output, True
+
+
+def get_std_type_lookup(net, table_name):
+    return np.array(list(net.std_types[table_name].keys()))

--- a/pandapipes/idx_branch.py
+++ b/pandapipes/idx_branch.py
@@ -41,10 +41,8 @@ FROM_NODE_T = 31
 TO_NODE_T = 32
 QEXT = 33  # heat input in [W]
 TEXT = 34
-STD_TYPE = 35
-PL = 36
-TL = 37  # Temperature lift [K]
-BRANCH_TYPE = 38  # branch type relevant for the pressure controller
-PRESSURE_RATIO = 39  # boost ratio for compressors with proportional pressure lift
+PL = 35
+TL = 36  # Temperature lift [K]
+BRANCH_TYPE = 37  # branch type relevant for the pressure controller
 
-branch_cols = 40
+branch_cols = 38

--- a/pandapipes/pf/pipeflow_setup.py
+++ b/pandapipes/pf/pipeflow_setup.py
@@ -352,6 +352,7 @@ def initialize_pit(net):
     for comp in net['component_list']:
         comp.create_pit_node_entries(net, pit["node"])
         comp.create_pit_branch_entries(net, pit["branch"])
+        comp.create_component_array(net, pit["components"])
     return pit["node"], pit["branch"]
 
 
@@ -375,7 +376,8 @@ def create_empty_pit(net):
     branch_length = get_lookup(net, "branch", "length")
     # init empty pit
     pit = {"node": np.empty((node_length, node_cols), dtype=np.float64),
-           "branch": np.empty((branch_length, branch_cols), dtype=np.float64)}
+           "branch": np.empty((branch_length, branch_cols), dtype=np.float64),
+           "components": {}}
     net["_pit"] = pit
     return pit
 


### PR DESCRIPTION
- added "components" dict of arrays to pit
- every component can create its own internal array if needed (create_component_array in base_component.py)
- moved PRESSURE_RATIO and STD_TYPE from branch_idx.py to internal arrays of pumps and compressors, as they are only needed right there