### PR TITLE
readthedocs.yml deprecation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,4 +10,4 @@ python:
        - method: pip
          path: .
          extra_requirements:
-            - docs
+            - doc

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,11 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: 3.9
+
 python:
-    version: 3.7
     install:
        - method: pip
          path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3.9
+    python: "3.9"
 
 python:
     install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,4 @@ build:
 
 python:
     install:
-       - method: pip
-         path: .
-         extra_requirements:
-            - doc
+      - requirements: doc/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Change Log
 - [CHANGED] connectivity check now separated by hydraulics and heat_transfer calculation, so that also results can differ in some rows (NaN or not)
 - [CHANGED] dynamic creation of lookups for getting pit as pandas tables
 - [CHANGED] components can have their own internal arrays for specific calculations (e.g. for compressor pressure ratio), so that the pit does not need to include such component specific entries
+- [CHANGED] .readthedocs.yml due to deprecation
 - [FIXED] in STANET converter: bug fix for heat exchanger creation and external temperatures of pipes added
 - [REMOVED] broken travis badge removed from readme
 


### PR DESCRIPTION
see also [read our blog post](https://blog.readthedocs.com/use-build-os-config/)