### PR TITLE
Hotfix for warning in case of given u_w_per_m2k in array form

### DIFF
--- a/src/pandapipes/component_models/__init__.py
+++ b/src/pandapipes/component_models/__init__.py
@@ -16,3 +16,4 @@ from pandapipes.component_models.pressure_control_component import *
 from pandapipes.component_models.compressor_component import *
 from pandapipes.component_models.flow_control_component import *
 from pandapipes.component_models.mass_storage_component import *
+from pandapipes.component_models.heat_consumer_component import *

--- a/src/pandapipes/component_models/component_toolbox.py
+++ b/src/pandapipes/component_models/component_toolbox.py
@@ -215,8 +215,8 @@ def get_component_array(net, component_name, component_type="branch", mode='hydr
     :return: component_array - internal array of the component
     :rtype: numpy.ndarray
     """
-    f_all, t_all = get_lookup(net, component_type, "from_to")[component_name]
     if not only_active:
         return net["_pit"]["components"][component_name]
+    f_all, t_all = get_lookup(net, component_type, "from_to")[component_name]
     in_service_elm = get_lookup(net, component_type, "active_%s"%mode)[f_all:t_all]
     return net["_pit"]["components"][component_name][in_service_elm]

--- a/src/pandapipes/create.py
+++ b/src/pandapipes/create.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2020-2024 by Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel, and University of Kassel. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from typing import Iterable
 
 import numpy as np
 import pandas as pd
@@ -1426,19 +1427,18 @@ def create_pipes_from_parameters(net, from_junctions, to_junctions, length_km, d
 
     if 'alpha_w_per_m2k' in kwargs:
 
-        if u_w_per_m2k == 0:
+        if (not isinstance(u_w_per_m2k, Iterable) and isinstance(u_w_per_m2k, float)
+                and u_w_per_m2k == 0.):
             u_w_per_m2k = kwargs['alpha_w_per_m2k']
 
-        warnings.warn("The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k." "It will be removed in future.", DeprecationWarning)
+        warnings.warn("The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k."
+                      "It will be removed in future.", DeprecationWarning)
 
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
                "std_type": None, "length_km": length_km, "diameter_m": diameter_m, "k_mm": k_mm,
                "loss_coefficient": loss_coefficient, "u_w_per_m2k": u_w_per_m2k,
                "sections": sections, "in_service": in_service, "type": type, "qext_w": qext_w,
                "text_k": text_k}
-
-
-
 
     if 'std_type' in kwargs:
         raise UserWarning('you have defined a std_type, however, using this function you can only '


### PR DESCRIPTION
in create_pipes_from_parameters, the check for the value of u_w_per_m2k in case of existing alpha is corrected (exception for given arrays of u)