### PR TITLE
Chore: EOL of python v 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
     needs: upload
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest -n=auto
       - name: Test with pytest and Codecov
         if: ${{ matrix.python-version == '3.11' }}
@@ -107,7 +107,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest -n=auto
 
   linting:
@@ -169,7 +169,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest --nbmake -n=auto "./tutorials"
 
   docs_check:

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -32,22 +32,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest pytest-split
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          python -m pip install .
+          python -m pip install .["all"]
         shell: bash
       - name: List all installed packages
         run: |
           python -m pip list
       - name: Test with pytest
-        if: ${{ matrix.python-version != '3.9' }}
+        if: ${{ matrix.python-version != '3.11' }}
         run: |
           python -m pytest
+      - name: Test without numba
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          python -m pip uninstall numba
+          python -m pytest -n=auto
       - name: Test with pytest and Codecov
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: |
           python -m pip install pytest-cov
           python -m pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@v1
         with:
           verbose: true
@@ -76,21 +81,16 @@ jobs:
         run: |
           python -m pip list
       - name: Test with pytest
-        if: ${{ matrix.python-version != '3.9' }}
+        if: ${{ matrix.python-version != '3.11' }}
         run: |
           python -m pytest
-      - name: Test with numba
-        if: ${{ matrix.python-version == '3.11' }}
-        run: |
-          python -m pip install numba
-          python -m pytest -n=auto
       - name: Test with pytest and Codecov
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: |
           python -m pip install pytest-cov
           python -m pytest -n=auto --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@v4
         with:
           verbose: true
@@ -104,12 +104,17 @@ jobs:
             'pandapipes/networks/network_files/**'
             '**.yml'
             '**.rst'
+      - name: Test without numba
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          python -m pip uninstall numba
+          python -m pytest -n=auto
 
   linting:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.11']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
@@ -161,17 +166,17 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --nbmake -n=auto "./tutorials"
-      - name: Test with numba
+      - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip install numba
+          python -m pip uninstall numba
           python -m pytest --nbmake -n=auto "./tutorials"
 
   docs_check:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.11' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages
@@ -72,8 +70,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest igraph pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install git+https://github.com/e2nIEE/pandapower@develop#egg=pandapower
           python -m pip install .["all"]
         shell: bash
@@ -126,7 +122,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install flake8
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages
@@ -156,8 +151,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==8.0.2 nbmake pytest-xdist pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
@@ -140,7 +140,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run_tests_develop.yml
+++ b/.github/workflows/run_tests_develop.yml
@@ -1,5 +1,5 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
-# A coverage report will be created for the Python 3.8 version
+# A coverage report will be created for the Python 3.9 version
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 # pandapipes-develop branch is designed to work with pandapower-develop branch

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -35,28 +35,23 @@ jobs:
         run: |
           python -m pip list
       - name: Test with pytest
-        if: ${{ matrix.python-version != '3.9' }}
+        if: ${{ matrix.python-version != '3.11' }}
         run: |
           python -m pytest
-      - name: Test with numba
-        if: ${{ matrix.python-version == '3.11' }}
-        run: |
-          python -m pip install numba
-          python -m pytest -n=auto
       - name: Test with pytest, Codecov and Coverage
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         run: |
           python -m pip install pytest-cov
           python -m pytest --nbmake -n=auto --cov=./ --cov-report=xml
           cp ./coverage.xml ./codecov_coverage.xml
       - name: Upload coverage to Codacy
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest'}}
+        if: ${{ matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'}}
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         run: |
           bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage.xml
       - name: Upload coverage to Codecov
-        if: ${{ matrix.python-version == '3.9' }}
+        if: ${{ matrix.python-version == '3.11' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -70,6 +65,11 @@ jobs:
             'pandapipes/networks/network_files/**'
             '**.yml'
             '**.rst'
+      - name: Test without numba
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          python -m pip uninstall numba
+          python -m pytest -n=auto
 
 
   relying:
@@ -95,8 +95,13 @@ jobs:
         run: |
           python -m pip list
       - name: Test with pytest
-        if: ${{ matrix.python-version != '3.9' }}
+        # if: ${{ matrix.python-version != '3.11' }}
         run: |
+          python -m pytest -n=auto
+      - name: Test without numba
+        if: ${{ matrix.python-version == '3.11' }}
+        run: |
+          python -m pip uninstall numba
           python -m pytest -n=auto
 
   tutorial_tests:
@@ -124,10 +129,10 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest --nbmake -n=auto "./tutorials"
-      - name: Test with numba
+      - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip install numba
+          python -m pip uninstall numba
           python -m pytest --nbmake -n=auto "./tutorials"
 
 
@@ -135,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.11' ]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest -n=auto
 
 
@@ -101,7 +101,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest -n=auto
 
   tutorial_tests:
@@ -132,7 +132,7 @@ jobs:
       - name: Test without numba
         if: ${{ matrix.python-version == '3.11' }}
         run: |
-          python -m pip uninstall numba
+          python -m pip uninstall numba -y
           python -m pytest --nbmake -n=auto "./tutorials"
 
 

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -27,8 +27,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages
@@ -87,8 +85,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages
@@ -119,8 +115,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest==8.0.2 nbmake pytest-xdist pytest-split
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           python -m pip install .["all"]
         shell: bash
       - name: List all installed packages

--- a/.github/workflows/run_tests_master.yml
+++ b/.github/workflows/run_tests_master.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os:  [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,14 @@ Change Log
 =============
 
 
--[ADDED] heat_consumer plotting
--[CHANGED] switched from setup.py to pyproject.toml
-- [CHANGED] variable "alpha_w_per_m2k" to "u_w_per_m2k"
-- [FIXED] Pressure plot not working for circ pump
+- [ADDED] heat_consumer plotting
 - [ADDED] variable "u_w_per_m2k" to std_type pipe
 - [ADDED] standard district heating pipe types
+- [ADDED] support for Python 3.12
+- [CHANGED] switched from setup.py to pyproject.toml
+- [CHANGED] variable "alpha_w_per_m2k" to "u_w_per_m2k"
+- [FIXED] Pressure plot not working for circ pump
+- [REMOVED] support for Python 3.8 due to EOL
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,13 @@ Changelog = "https://github.com/e2nIEE/pandapipes/blob/develop/CHANGELOG.rst"
 [project.optional-dependencies]
 docs = ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex", "sphinx-pyproject"]
 plotting = ["plotly", "igraph"]
-test = ["pytest", "pytest-xdist", "nbmake", "numba", "setuptools; python_version >= '3.12'"]
+test = [
+    "pytest", "pytest-xdist", "pytest-split", "nbmake", "numba",
+    "setuptools; python_version >= '3.12'"
+]
 all = [
     "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake", "numba",
+    "plotly", "igraph", "pytest", "pytest-xdist", "pytest-split", "nbmake", "numba",
     "setuptools; python_version >= '3.12'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'pandapower ~= 2.14.6',
     'matplotlib',
     'shapely',
-    'setuptools; python_version == "3.12"',
+    'setuptools; python_version >= "3.12"',
 ]
 keywords = [
     "network", "analysis", "optimization", "automation", "grid", "energy", "engineering", "simulation", "pipeflow", "pandapipes", "gas"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,11 @@ Changelog = "https://github.com/e2nIEE/pandapipes/blob/develop/CHANGELOG.rst"
 [project.optional-dependencies]
 docs = ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex", "sphinx-pyproject"]
 plotting = ["plotly", "igraph"]
-test = ["pytest", "pytest-xdist", "nbmake"]
+test = ["pytest", "pytest-xdist", "nbmake", "numba", "setuptools; python_version >= '3.12'"]
 all = [
     "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake"
+    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake", "numba",
+    "setuptools; python_version >= '3.12'"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,13 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    'pandapower ~= 2.14.6',
-    'matplotlib',
-    'shapely',
-    'setuptools; python_version >= "3.12"',
+    "pandapower ~= 2.14.6",
+    "matplotlib",
+    "shapely",
 ]
 keywords = [
-    "network", "analysis", "optimization", "automation", "grid", "energy", "engineering", "simulation", "pipeflow", "pandapipes", "gas"
+    "network", "analysis", "optimization", "automation", "grid", "energy", "engineering",
+    "simulation", "pipeflow", "pandapipes", "gas"
 ]
 
 [project.urls]
@@ -53,10 +53,10 @@ Changelog = "https://github.com/e2nIEE/pandapipes/blob/develop/CHANGELOG.rst"
 [project.optional-dependencies]
 docs = ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex", "sphinx-pyproject"]
 plotting = ["plotly", "igraph"]
-test = ["pytest", "pytest-xdist", "nbmake"]
+test = ["pytest", "pytest-xdist", "nbmake", "setuptools; python_version >= '3.12'"]
 all = [
     "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake"
+    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake", "setuptools; python_version >= '3.12'"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors=[
 description = "A pipeflow calculation tool that complements pandapower in the simulation of multi energy grids"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -26,7 +26,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     # Add the specific Python versions supported here, e.g.:
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,10 @@ Changelog = "https://github.com/e2nIEE/pandapipes/blob/develop/CHANGELOG.rst"
 [project.optional-dependencies]
 docs = ["numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex", "sphinx-pyproject"]
 plotting = ["plotly", "igraph"]
-test = ["pytest", "pytest-xdist", "nbmake", "setuptools; python_version >= '3.12'"]
+test = ["pytest", "pytest-xdist", "nbmake"]
 all = [
     "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake", "setuptools; python_version >= '3.12'"
+    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ classifiers = [
     "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-    "pandapower ~= 2.14.6",
-    "matplotlib",
-    "shapely",
+    'pandapower ~= 2.14.6',
+    'matplotlib',
+    'shapely',
+    'setuptools; python_version == "3.12"',
 ]
 keywords = [
     "network", "analysis", "optimization", "automation", "grid", "energy", "engineering", "simulation", "pipeflow", "pandapipes", "gas"
@@ -55,8 +56,7 @@ plotting = ["plotly", "igraph"]
 test = ["pytest", "pytest-xdist", "nbmake"]
 all = [
     "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinxcontrib.bibtex",
-    "plotly", "igraph",
-    "pytest", "pytest-xdist", "nbmake"
+    "plotly", "igraph", "pytest", "pytest-xdist", "nbmake"
 ]
 
 [tool.setuptools.packages.find]

--- a/src/pandapipes/test/test_imports.py
+++ b/src/pandapipes/test/test_imports.py
@@ -8,11 +8,28 @@ import os
 
 import pytest
 from pandapipes import pp_dir
-from setuptools import find_packages
+try:
+    from setuptools import find_packages
+    SETUPTOOLS_AVAILABLE = True
+except ImportError:
+    SETUPTOOLS_AVAILABLE = False
 
 
 def test_import_packages():
-    all_packages = find_packages(pp_dir)
+    if SETUPTOOLS_AVAILABLE:
+        all_packages = find_packages(pp_dir)
+    else:
+        all_packages = []
+        for root, dirs, files in os.walk(pp_dir):
+            for file in files:
+                if file != "__init__.py":
+                    continue
+                path = os.path.relpath(root, pp_dir)
+                if path == ".":
+                    continue
+                pck = path.replace(os.sep, ".")
+                all_packages.append(pck)
+
     for pck in all_packages:
         spec = importlib.util.find_spec(os.path.split(pp_dir)[-1] + "." + pck)
         new_module = importlib.util.module_from_spec(spec)

--- a/src/pandapipes/test/test_imports.py
+++ b/src/pandapipes/test/test_imports.py
@@ -15,21 +15,9 @@ except ImportError:
     SETUPTOOLS_AVAILABLE = False
 
 
+@pytest.mark.skipif(not SETUPTOOLS_AVAILABLE, reason="setuptools not available")
 def test_import_packages():
-    if SETUPTOOLS_AVAILABLE:
-        all_packages = find_packages(pp_dir)
-    else:
-        all_packages = []
-        for root, dirs, files in os.walk(pp_dir):
-            for file in files:
-                if file != "__init__.py":
-                    continue
-                path = os.path.relpath(root, pp_dir)
-                if path == ".":
-                    continue
-                pck = path.replace(os.sep, ".")
-                all_packages.append(pck)
-
+    all_packages = find_packages(pp_dir)
     for pck in all_packages:
         spec = importlib.util.find_spec(os.path.split(pp_dir)[-1] + "." + pck)
         new_module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
chore: removed python 3.8 from pyproject.toml and from all python versions in workflow matrix

TODO: We should check for the python versions with which to run

- codacy
- codecov
- some numba stuff (currently done with python 3.11)