### PR TITLE
Edit default output writer

### DIFF
--- a/src/pandapipes/test/pipeflow_internals/test_time_series.py
+++ b/src/pandapipes/test/pipeflow_internals/test_time_series.py
@@ -79,6 +79,7 @@ def _data_source():
 
 
 def _compare_results(ow):
+    _compare_results_default_ow(ow)
     test_res_ext_grid = pd.read_csv(os.path.join(data_path, 'test_time_series_results', 'res_ext_grid',
         'mdot_kg_per_s.csv'), sep=';', index_col=0)
     res_ext_grid = ow.np_results["res_ext_grid.mdot_kg_per_s"]
@@ -87,6 +88,25 @@ def _compare_results(ow):
     diff = 1 - res_ext_grid.round(9) / test_res_ext_grid.round(9)
     check = diff < 0.0001
     assert (np.all(check))
+    test_res_sink = pd.read_csv(os.path.join(data_path, 'test_time_series_results', 'res_sink',
+        'mdot_kg_per_s.csv'), sep=';', index_col=0)
+    res_sink = ow.np_results["res_sink.mdot_kg_per_s"]
+    res_sink = res_sink[~np.isclose(res_sink, 0)]
+    test_res_sink = test_res_sink.values[~np.isclose(test_res_sink.values, 0)]
+    diff = 1 - res_sink.round(9) / test_res_sink.round(9)
+    check = diff < 0.0001
+    assert (np.all(check))
+    test_res_source = pd.read_csv(os.path.join(data_path, 'test_time_series_results', 'res_source',
+        'mdot_kg_per_s.csv'), sep=';', index_col=0)
+    res_source = ow.np_results["res_source.mdot_kg_per_s"]
+    res_source = res_source[~np.isclose(res_source, 0)]
+    test_res_source = test_res_source.values[~np.isclose(test_res_source.values, 0)]
+    diff = 1 - res_source.round(9) / test_res_source.round(9)
+    check = diff < 0.0001
+    assert (np.all(check))
+
+
+def _compare_results_default_ow(ow):
     test_res_junction = pd.read_csv(os.path.join(data_path, 'test_time_series_results', 'res_junction',
         'p_bar.csv'), sep=';', index_col=0)
     res_junction = ow.np_results["res_junction.p_bar"]
@@ -101,22 +121,6 @@ def _compare_results(ow):
     res_pipe = res_pipe[~np.isclose(res_pipe, 0)]
     test_res_pipe = test_res_pipe.values[~np.isclose(test_res_pipe.values, 0)]
     diff = 1 - res_pipe.round(9) / test_res_pipe.round(9)
-    check = diff < 0.0001
-    assert (np.all(check))
-    test_res_sink = pd.read_csv(os.path.join(data_path, 'test_time_series_results', 'res_sink',
-        'mdot_kg_per_s.csv'), sep=';', index_col=0)
-    res_sink = ow.np_results["res_sink.mdot_kg_per_s"]
-    res_sink = res_sink[~np.isclose(res_sink, 0)]
-    test_res_sink = test_res_sink.values[~np.isclose(test_res_sink.values, 0)]
-    diff = 1 - res_sink.round(9) / test_res_sink.round(9)
-    check = diff < 0.0001
-    assert (np.all(check))
-    test_res_source = pd.read_csv(os.path.join(data_path, 'test_time_series_results',
-        'res_source', 'mdot_kg_per_s.csv'), sep=';', index_col=0)
-    res_source = ow.np_results["res_source.mdot_kg_per_s"]
-    res_source = res_source[~np.isclose(res_source, 0)]
-    test_res_source = test_res_source.values[~np.isclose(test_res_source.values, 0)]
-    diff = 1 - res_source.round(9) / test_res_source.round(9)
     check = diff < 0.0001
     assert (np.all(check))
 
@@ -173,7 +177,7 @@ def test_time_series_default_ow():
     max_iter_hyd = 8
     run_timeseries(net, time_steps, max_iter_hyd=max_iter_hyd, calc_compression_power = False)
     ow = net.output_writer.iat[0, 0]
-    _compare_results(ow)
+    _compare_results_default_ow(ow)
 
 
 if __name__ == "__main__":

--- a/src/pandapipes/timeseries/run_time_series.py
+++ b/src/pandapipes/timeseries/run_time_series.py
@@ -39,9 +39,6 @@ def init_default_outputwriter(net, time_steps, **kwargs):
         net.output_writer.iat[0, 0] = output_writer
     if "output_writer" not in net or net.output_writer.iat[0, 0] is None:
         ow = OutputWriter(net, time_steps, output_path=tempfile.gettempdir(), log_variables=[])
-        ow.log_variable('res_sink', 'mdot_kg_per_s')
-        ow.log_variable('res_source', 'mdot_kg_per_s')
-        ow.log_variable('res_ext_grid', 'mdot_kg_per_s')
         ow.log_variable('res_pipe', 'v_mean_m_per_s')
         ow.log_variable('res_junction', 'p_bar')
         ow.log_variable('res_junction', 't_k')


### PR DESCRIPTION
Remove the results from source, sink and ext_grid from the default OutputWriter and edit the testing accordingly, because cannot assume that the network will contain these elements.

I was running a timeseries calculation with a District Heating Network, which has no source, sink and ext_grid and figured out that I need to explicitly defined an OutputWriter as the default one assume that these elements are present in the network.

It seems safe to assume that junctions and pipes are always part of the network though.