### PR TITLE
Changed heat consumer flow control when qext_w is zero

### DIFF
--- a/src/pandapipes/component_models/heat_consumer_component.py
+++ b/src/pandapipes/component_models/heat_consumer_component.py
@@ -78,12 +78,15 @@ class HeatConsumer(BranchWZeroLengthComponent):
         treturn = net[cls.table_name()].treturn_k.values
         hc_pit[~np.isnan(treturn), TOUTINIT] = treturn[~np.isnan(treturn)]
         hc_pit[:, FLOW_RETURN_CONNECT] = True
-        mask_q0 = qext == 0 & np.isnan(mdot)
+        
+        # Ensure no flow occurs through the heat consumer when qext_w is zero
+        mask_q0 = qext == 0
         if np.any(mask_q0):
-            hc_pit[mask_q0, ACTIVE] = False
+            hc_pit[mask_q0, MDOTINIT] = 0  # Set mass flow to zero
             logger.warning(r'qext_w is equals to zero for heat consumers with index %s. '
-                           r'Therefore, the defined temperature control cannot be maintained.' \
+                           r'Setting mdot to zero to ensure no flow.' \
                     %net[cls.table_name()].index[mask_q0])
+        
         return hc_pit
 
     @classmethod


### PR DESCRIPTION
In reference to Issue #679 regarding time series calculation problems, I tested setting the mass flow in the heat consumer to zero instead of deactivating the component. This approach seems to resolve the issue I encountered. What are your thoughts on this change? Do you see alternative solutions?

Additionally, I face two further challenges:

- How should the network handle scenarios where all heat consumers have a qext_w of zero in a time step?
- During time steps with minimal overall load, the temperature drops below the heat consumers' return temperature, causing pipeflow to fail due to cooling in the pipes. Increasing text_k in the pipes mitigates the problem, but the results become unrealistic since the ground temperature is not accurately reflected.

What would you recommend to address these challenges?