### PR TITLE
add documentation for Hofer, add transition area approach

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 =============
 
+[upcoming release] - 2025-xx-xx
+-------------------------------
+- [ADDED] Hofer formula for friction factor "lambda"
+
 [0.11.0] - 2024-11-07
 -------------------------------
 - [ADDED] heat_consumer plotting
@@ -27,8 +31,6 @@ Change Log
 - [FIXED] Heat consumers with qext_w = 0 and temperature control ignore temperature set points
 - [FIXED] alpha also applied to mdot
 - [REMOVED] support for Python 3.8 due to EOL
-
-
 
 [0.10.0] - 2024-04-09
 -------------------------------

--- a/doc/source/components/pipe/pipe_component.rst
+++ b/doc/source/components/pipe/pipe_component.rst
@@ -156,7 +156,7 @@ They are set by the :code:`friction_model` parameter and the name given in paren
    :nowrap:
 
    \begin{align*}
-    \lambda &= \frac{64}{Re} + \frac{1}{(-2 \cdot \log (\frac{k}{3.71 \cdot d}))^2}\\
+    \lambda &= \frac{64}{Re} + \frac{1}{\left(-2 \cdot \log \left(\frac{k}{3.71 \cdot d}\right)\right)^2}\\
    \end{align*}
 
 
@@ -169,7 +169,7 @@ If *Prandtl-Colebrook* (also known as Colebrook-White) is selected, the friction
    :nowrap:
 
    \begin{align*}
-     \frac{1}{\sqrt{\lambda}} &= -2 \cdot \log (\frac{2.51}{Re \cdot \sqrt{\lambda}} + \frac{k}{3.71 \cdot d})\\
+     \frac{1}{\sqrt{\lambda}} &= -2 \cdot \log \left(\frac{2.51}{Re \cdot \sqrt{\lambda}} + \frac{k}{3.71 \cdot d}\right)\\
    \end{align*}
 
 Equations for pressure losses due to friction were taken from :cite:`Eberhard1990` and
@@ -182,7 +182,7 @@ The *Hofer-Equation* is an explicit approximation of the Prandtl-Colebrook metho
    :nowrap:
 
    \begin{align*}
-    \lambda_H &= \frac{1}{(-2 \log (\frac{4.518}{Re} \cdot \log (\frac{Re}{7}) + \frac{k}{3.71 \cdot d}))^2}\\
+    \lambda_H &= \frac{1}{(-2 \log \left(\frac{4.518}{Re} \cdot \log \left(\frac{Re}{7}) + \frac{k}{3.71 \cdot d}\right)\right)^2}\\
    \end{align*}
 
 Very small Reynolds numbers can lead to problems with the two nested log-functions.
@@ -200,7 +200,7 @@ zone of turbulent flows in pipes and is defined as follows:
    :nowrap:
 
    \begin{align*}
-    \lambda &= \frac{0.25}{(\log(\frac{k}{3.7 \cdot d} + \frac{5.74}{Re^{0.9}}))^2}\\
+    \lambda &= \frac{0.25}{\left(\log\left(\frac{k}{3.7 \cdot d} + \frac{5.74}{Re^{0.9}}\right)\right)^2}\\
    \end{align*}
 
 

--- a/doc/source/components/pipe/pipe_component.rst
+++ b/doc/source/components/pipe/pipe_component.rst
@@ -142,13 +142,15 @@ pipe sections.
 Friction models
 ^^^^^^^^^^^^^^^
 
-Three friction models are used to calculate the velocity dependent friction factor:
+For friction models are available to calculate the velocity dependent friction factor :math:`\lambda`:
 
-- Nikuradse
-- Prandtl-Colebrook
-- Swamee-Jain
+- Nikuradse ("nikuradse")
+- Prandtl-Colebrook ("colebrook")
+- Hofer ("hofer")
+- Swamee-Jain ("swamee-jain")
 
-Nikuradse is chosen by default. In this case, the friction factor is calculated by:
+They are set by the :code:`friction_model` parameter and the name given in parentheses.
+*Nikuradse* is chosen by default. In this case, the friction factor is calculated by:
 
 .. math::
    :nowrap:
@@ -161,7 +163,7 @@ Nikuradse is chosen by default. In this case, the friction factor is calculated 
 Note that in literature, Nikuradse is known as a model for turbulent flows. In pandapipes, the formula for the
 Nikuradse model is also applied for laminar flow.
 
-If Prandtl-Colebrook is selected, the friction factor is calculated iteratively according to
+If *Prandtl-Colebrook* (also known as Colebrook-White) is selected, the friction factor is calculated iteratively according to
 
 .. math::
    :nowrap:
@@ -173,7 +175,24 @@ If Prandtl-Colebrook is selected, the friction factor is calculated iteratively 
 Equations for pressure losses due to friction were taken from :cite:`Eberhard1990` and
 :cite:`Cerbe2008`.
 
-The equation according to Swamee-Jain :cite:`Swamee1976` is an approximation of the calculation method according
+The *Hofer-Equation* is an explicit approximation of the Prandtl-Colebrook method and defined as shown in
+:cite:`Benner.2019` (based on :cite:`Hofer.1973`)
+
+.. math::
+   :nowrap:
+
+   \begin{align*}
+    \lambda_H &= \frac{1}{(-2 \log (\frac{4.518}{Re} \cdot \log (\frac{Re}{7}) + \frac{k}{3.71 \cdot d}))^2}\\
+   \end{align*}
+
+Very small Reynolds numbers can lead to problems with the two nested log-functions.
+Thus, in pandapipes, the laminar :math:`\lambda_l = 64/Re` is applied for small Reynolds numbers
+(:math:`Re < \underline{Re}`) and :math:`\lambda_H` is used for high Reynolds numbers (:math:`Re > \overline{Re}`).
+In the transition area :math:`\underline{Re} \leq Re \leq \overline{Re}`, :math:`\lambda_H` is interpolated linearly.
+By default, the boundaries of this transition area are set to :math:`\underline{Re}=2000` and :math:`\overline{Re}=3000`.
+Note that the derivative used for Hofer is the same as for Prandtl-Colebrook.
+
+The equation according to *Swamee-Jain* :cite:`Swamee1976` is another approximation of the calculation method according
 to Prandtl-Colebrook. It is an explicit formula for the friction factor of the transition
 zone of turbulent flows in pipes and is defined as follows:
 

--- a/doc/source/pipeflow/calculation_modes.rst
+++ b/doc/source/pipeflow/calculation_modes.rst
@@ -92,7 +92,7 @@ In gas flows, the velocity is typically not constant along a pipeline. For this 
 tables for pipes show more entries in comparison with the result tables for incompressible media.
 
 
-Temperature calculations (pipeflow option: mode = "sequential", mode = "bidrectional" or mode = "heat")
+Temperature calculations (pipeflow option: mode = "sequential", mode = "bidirectional" or mode = "heat")
 =======================================================================================================
 
 Important parameters of the network main components (junctions and pipes) needed for the calculation

--- a/doc/source/references.bib
+++ b/doc/source/references.bib
@@ -82,3 +82,39 @@
  journal = {Optimization and Engineering},
  doi = {10.1007/s11081-014-9246-x}
 }
+
+
+@incollection{Benner.2019,
+ author = {Benner, Peter and Grundel, Sara and Himpe, Christian and Huck, Christoph and Streubel, Tom and Tischendorf, Caren},
+ title = {Gas Network Benchmark Models},
+ pages = {171--197},
+ publisher = {{Springer International Publishing}},
+ isbn = {978-3-030-03717-8},
+ series = {Differential-Algebraic Equations Forum},
+ editor = {Campbell, Stephen and Ilchmann, Achim and Mehrmann, Volker and Reis, Timo},
+ booktitle = {Applications of Differential-Algebraic Equations: Examples and Benchmarks},
+ year = {2019},
+ address = {Cham},
+ doi = {10.1007/11221{\_}2018{\_}5},
+}
+
+@book{Campbell.2019,
+ year = {2019},
+ title = {Applications of Differential-Algebraic Equations: Examples and Benchmarks},
+ address = {Cham},
+ publisher = {{Springer International Publishing}},
+ isbn = {978-3-030-03717-8},
+ series = {Differential-Algebraic Equations Forum},
+ editor = {Campbell, Stephen and Ilchmann, Achim and Mehrmann, Volker and Reis, Timo},
+ doi = {10.1007/978-3-030-03718-5}
+}
+
+@article{Hofer.1973,
+ author = {Hofer, P.},
+ year = {1973},
+ title = {Beurteilung von Fehlern in Rohrnetzberechnungen},
+ pages = {113--119},
+ volume = {114},
+ number = {3},
+ journal = {Das Gas- und Wasserfach. GWF - Ausgabe Wasser, Abwasser}
+}

--- a/doc/source/references.bib
+++ b/doc/source/references.bib
@@ -95,7 +95,7 @@
  booktitle = {Applications of Differential-Algebraic Equations: Examples and Benchmarks},
  year = {2019},
  address = {Cham},
- doi = {10.1007/11221{\_}2018{\_}5},
+ doi = {10.1007/11221_2018_5},
 }
 
 @book{Campbell.2019,
@@ -112,7 +112,7 @@
 @article{Hofer.1973,
  author = {Hofer, P.},
  year = {1973},
- title = {Beurteilung von Fehlern in Rohrnetzberechnungen},
+ title = {{Beurteilung von Fehlern in Rohrnetzberechnungen}},
  pages = {113--119},
  volume = {114},
  number = {3},


### PR DESCRIPTION
The friction factor "Hofer" is introduced. It is an explicit implementation of Colebrook, used by some industrial Gas Grid Simulation tools.
Please refer to the added paragraph in the [docs](https://pandapipes-jkisse-fork.readthedocs.io/en/feature-hofer/components/pipe/pipe_component.html#friction-models) for more details. 