### PR TITLE
add explicit call of Sphinx-Config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,7 @@ python:
         path: .
         extra_requirements:
           - docs
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: doc/source/conf.py


### PR DESCRIPTION
* cf. https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Docs cannot be built anymore if there is no explicit call of the Sphinx-Config-File.

Urgent merge necessary because all doc-checks fail otherwise.