### PR TITLE
Correct controller documentation

### DIFF
--- a/doc/source/controller/run.rst
+++ b/doc/source/controller/run.rst
@@ -21,7 +21,7 @@ Internally, this function calls the control loop implemented in pandapower.
 
 .. code::
 
-	from pandapipes.control.run_control import run_control_ppipe
+	from pandapipes.control.run_control import run_control as run_control_ppipe
 	run_control_ppipe(net)
 
 .. _run_control_ppipe:


### PR DESCRIPTION
I found a small mistake in the doc, the function is named run_control, like in pandapower