### PR TITLE
avoid bool(in_service) for bulk create functions

### DIFF
--- a/src/pandapipes/create.py
+++ b/src/pandapipes/create.py
@@ -1692,7 +1692,7 @@ def create_heat_exchangers(net, from_junctions, to_junctions, qext_w, loss_coeff
     _check_branches(net, from_junctions, to_junctions, "heat_exchanger")
 
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
-               "qext_w": qext_w, "loss_coefficient": loss_coefficient, "in_service": bool(in_service), "type": type}
+               "qext_w": qext_w, "loss_coefficient": loss_coefficient, "in_service": in_service, "type": type}
     _set_multiple_entries(net, "heat_exchanger", index, **entries, **kwargs)
 
     return index
@@ -1763,7 +1763,7 @@ def create_heat_consumers(net, from_junctions, to_junctions, qext_w=None, contro
 
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
                "qext_w": qext_w, "controlled_mdot_kg_per_s": controlled_mdot_kg_per_s, "deltat_k": deltat_k,
-               "treturn_k": treturn_k, "in_service": bool(in_service), "type": type}
+               "treturn_k": treturn_k, "in_service": in_service, "type": type}
     _set_multiple_entries(net, "heat_consumer", index, **entries, **kwargs)
     return index
 


### PR DESCRIPTION
let set_multiple_entries and preserve_dtypes handle bool dtype coercion for heat consumers and exchangers (error in implementation)