### PR TITLE
Fix/json decoder old pandapower

### DIFF
--- a/src/pandapipes/io/io_utils.py
+++ b/src/pandapipes/io/io_utils.py
@@ -3,19 +3,19 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 import importlib
+import inspect
 import json
 from copy import deepcopy
 from functools import partial
 from inspect import isclass
 from warnings import warn
 
-from pandapower.io_utils import pp_hook
-from pandapower.io_utils import with_signature, to_serializable, JSONSerializableClass, \
-    isinstance_partial as ppow_isinstance, FromSerializableRegistry, PPJSONDecoder
-
 from pandapipes.component_models.abstract_models.branch_models import Component
 from pandapipes.multinet.create_multinet import MultiNet, create_empty_multinet
 from pandapipes.pandapipes_net import pandapipesNet, get_basic_net_entries
+from pandapower.io_utils import pp_hook
+from pandapower.io_utils import with_signature, to_serializable, JSONSerializableClass, \
+    isinstance_partial as ppow_isinstance, FromSerializableRegistry, PPJSONDecoder
 
 try:
     import pandaplan.core.pplog as logging
@@ -52,7 +52,12 @@ class FromSerializableRegistryPpipe(FromSerializableRegistry):
         :param ppipes_hook: a way how to handle non-default data
         :type ppipes_hook: funct
         """
-        super().__init__(obj, d, ppipes_hook, ignore_unknown_objects)
+        # for pandapower version < 3.0.0, ignore_unknown_objects is not passed
+        if "ignore_unknown_objects" in inspect.signature(super().__init__).parameters:
+            super().__init__(obj, d, ppipes_hook, ignore_unknown_objects=ignore_unknown_objects)
+        else:
+            super().__init__(obj, d, ppipes_hook)
+            self.ignore_unknown_objects = ignore_unknown_objects
 
     @from_serializable.register(class_name="method")
     def method(self):

--- a/src/pandapipes/io/io_utils.py
+++ b/src/pandapipes/io/io_utils.py
@@ -101,10 +101,12 @@ class FromSerializableRegistryPpipe(FromSerializableRegistry):
                 raise e
         if isclass(class_) and issubclass(class_, JSONSerializableClass):
             if isinstance(self.obj, str):
+                partial_args = {"registry_class": FromSerializableRegistryPpipe,}
+                if inspect.signature(pp_hook).parameters.get("ignore_unknown_objects"):
+                    partial_args["ignore_unknown_objects"] = self.ignore_unknown_objects
                 self.obj = json.loads(
                     self.obj, cls=PPJSONDecoder,
-                    object_hook=partial(pp_hook, registry_class=FromSerializableRegistryPpipe,
-                                        ignore_unknown_objects=self.ignore_unknown_objects)
+                    object_hook=partial(pp_hook, **partial_args)
                 )
                 # backwards compatibility
             if "net" in self.obj:


### PR DESCRIPTION
For pandapower < 3.0.0, the keyword "ignore_unknown_objects" from PR #665 is not accepted and thus the JSONDecoder raises an error. To avoid this error, this fix checks for the argument in the decoder's and registry's signatures.