### PR TITLE
Modified output writer to log only existing components to avoid errors

### DIFF
--- a/src/pandapipes/timeseries/run_time_series.py
+++ b/src/pandapipes/timeseries/run_time_series.py
@@ -37,14 +37,29 @@ def init_default_outputwriter(net, time_steps, **kwargs):
         logger.warning("deprecated: output_writer should not be given to run_timeseries(). "
                        "This overwrites the stored one in net.output_writer.")
         net.output_writer.iat[0, 0] = output_writer
+        
+    # If no output_writer exists, create one
     if "output_writer" not in net or net.output_writer.iat[0, 0] is None:
         ow = OutputWriter(net, time_steps, output_path=tempfile.gettempdir(), log_variables=[])
-        ow.log_variable('res_sink', 'mdot_kg_per_s')
-        ow.log_variable('res_source', 'mdot_kg_per_s')
-        ow.log_variable('res_ext_grid', 'mdot_kg_per_s')
-        ow.log_variable('res_pipe', 'v_mean_m_per_s')
-        ow.log_variable('res_junction', 'p_bar')
-        ow.log_variable('res_junction', 't_k')
+        
+        # Define a mapping of network components to result variables
+        component_to_variables = {
+            'sink': [('res_sink', 'mdot_kg_per_s')],
+            'source': [('res_source', 'mdot_kg_per_s')],
+            'ext_grid': [('res_ext_grid', 'mdot_kg_per_s')],
+            'pipe': [('res_pipe', 'v_mean_m_per_s'),
+                     ('res_pipe', 't_from_k'),  
+                     ('res_pipe', 't_to_k')],   
+            'junction': [('res_junction', 'p_bar'),
+                         ('res_junction', 't_k')]
+        }
+        
+        # Iterate through the mapping and log variables for existing components
+        for component, variables in component_to_variables.items():
+            if hasattr(net, component):  # Check if the component exists in the network
+                for var, value in variables:
+                    ow.log_variable(var, value)
+
         logger.info("No output writer specified. Using default:")
         logger.info(ow)
 


### PR DESCRIPTION
This update modifies the init_default_outputwriter function to check whether components exist in the network before logging their variables. Previously, the function unconditionally logged variables for certain components (like sinks, sources, pipes, etc.), which caused errors when those components were missing from the network. By adding checks with hasattr(net, component), the output writer now only logs variables for components that are actually present, improving robustness and preventing runtime errors during time series calculations.