### PR TITLE
Improve readability of setting pipeflow options

### DIFF
--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -279,16 +279,22 @@ def init_options(net, **kwargs):
 
     """
     user_pf_options = net.get("user_pf_options", {})
-    default_opts, user_pf_options, kwargs = map(copy.deepcopy, (default_options, user_pf_options, kwargs))
-    *_, = map(_iteration_check, (user_pf_options, kwargs))
+
+    # prevent mutations
+    default_options_copy = copy.deepcopy(default_options)
+    user_pf_options_copy = copy.deepcopy(user_pf_options)
+    kwargs_copy = copy.deepcopy(kwargs)
+
+    for obj in (user_pf_options_copy, kwargs_copy):
+        _iteration_check(obj)
 
     opts = {
         # Base layer: default options (lowest priority)
-        **default_opts,
-        # Middle layer: network-level options (overrides defaults)
-        **user_pf_options,
+        **default_options_copy,
+        # Middle layer: net options (overrides defaults)
+        **user_pf_options_copy,
         # Top layer: call-specific parameters (highest priority)
-        **kwargs,
+        **kwargs_copy,
     }
 
     keys_to_exclude = {"interactive_plotting", "t_start"}
@@ -339,7 +345,7 @@ def _mode_check(opts):
             "mode 'all' is deprecated and will be removed in a future release. "
             "Use 'sequential' or 'bidirectional' instead. "
             "For now 'all' is set equal to 'sequential'.",
-            FutureWarning
+            FutureWarning,
         )
         opts["mode"] = "sequential"
 

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 import copy
+import warnings
 
 import numpy as np
 from pandapower.auxiliary import ppException
@@ -292,9 +293,10 @@ def init_options(net, local_parameters):
         opts["reuse_internal_data"] = False
     if not numba_installed:
         if opts["use_numba"]:
-            logger.info(
+            warnings.warn(
                 "numba is not installed. Install numba first before you set the 'use_numba'"
-                " flag to True. The pipeflow will be performed without numba speedup."
+                " flag to True. The pipeflow will be performed without numba speedup.",
+                UserWarning,
             )
         opts["use_numba"] = False
     opts["fluid"] = get_fluid.name
@@ -312,7 +314,10 @@ def _iteration_check(opts):
         if n_iter is not None:
             # if both defined
             if key in opts:
-                logger.info(f"Overwriting {iter_key!r} with {key!r}")
+                warnings.warn(
+                    f"Overwriting {iter_key!r} with {key!r}",
+                    UserWarning,
+                )
             else:
                 opts[key] = n_iter
         # none defined
@@ -324,10 +329,11 @@ def _iteration_check(opts):
 def _check_mode(opts):
     mode = opts.get("mode", None)
     if mode == "all":
-        logger.warning(
+        warnings.warn(
             "mode 'all' is deprecated and will be removed in a future release. "
             "Use 'sequential' or 'bidirectional' instead. "
-            "For now 'all' is set equal to 'sequential'."
+            "For now 'all' is set equal to 'sequential'.",
+            FutureWarning
         )
         opts["mode"] = "sequential"
 

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -279,8 +279,8 @@ def init_options(net, **kwargs):
 
     """
     user_pf_options = net.get("user_pf_options", {})
-    default_opts, *aux_opts = map(copy.deepcopy, (default_options, user_pf_options, kwargs))
-    user_pf_options, kwargs = map(_iteration_check, aux_opts)
+    default_opts, user_pf_options, kwargs = map(copy.deepcopy, (default_options, user_pf_options, kwargs))
+    *_, = map(_iteration_check, (user_pf_options, kwargs))
 
     opts = {
         # Base layer: default options (lowest priority)
@@ -313,7 +313,7 @@ def init_options(net, **kwargs):
 
 def _iteration_check(opts):
     if not opts:
-        return opts
+        return
 
     modes = "hyd", "therm", "bidirect"
     iter_key = "iter"
@@ -330,7 +330,6 @@ def _iteration_check(opts):
                 )
             else:
                 opts[key] = n_iter
-    return opts
 
 
 def _mode_check(opts):

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -339,8 +339,7 @@ def _iteration_check(opts):
 
 
 def _mode_check(opts):
-    mode = opts.get("mode", None)
-    if mode == "all":
+    if opts["mode"] == "all":
         warnings.warn(
             "mode 'all' is deprecated and will be removed in a future release. "
             "Use 'sequential' or 'bidirectional' instead. "

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -3,7 +3,6 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 import copy
-import warnings
 
 import numpy as np
 from pandapower.auxiliary import ppException
@@ -305,10 +304,9 @@ def init_options(net, **kwargs):
         opts["reuse_internal_data"] = False
     if not numba_installed:
         if opts["use_numba"]:
-            warnings.warn(
+            logger.info(
                 "numba is not installed. Install numba first before you set the 'use_numba'"
                 " flag to True. The pipeflow will be performed without numba speedup.",
-                UserWarning,
             )
         opts["use_numba"] = False
     opts["fluid"] = get_fluid(net).name
@@ -330,9 +328,8 @@ def _iteration_check(opts):
         if n_iter is not None:
             # if both defined
             if key in opts:
-                warnings.warn(
-                    f"Overwriting {iter_key!r} with {key!r}",
-                    UserWarning,
+                logger.info(
+                    f"{key!r} will overwrite {iter_key!r}",
                 )
             else:
                 opts[key] = n_iter
@@ -340,11 +337,10 @@ def _iteration_check(opts):
 
 def _mode_check(opts):
     if opts["mode"] == "all":
-        warnings.warn(
+        logger.warning(
             "mode 'all' is deprecated and will be removed in a future release. "
             "Use 'sequential' or 'bidirectional' instead. "
             "For now 'all' is set equal to 'sequential'.",
-            FutureWarning,
         )
         opts["mode"] = "sequential"
 

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -284,8 +284,8 @@ def init_options(net, **kwargs):
     user_pf_options_copy = copy.deepcopy(user_pf_options)
     kwargs_copy = copy.deepcopy(kwargs)
 
-    for obj in (user_pf_options_copy, kwargs_copy):
-        _iteration_check(obj)
+    for options in (user_pf_options_copy, kwargs_copy):
+        _iteration_check(options)
 
     opts = {
         # Base layer: default options (lowest priority)

--- a/src/pandapipes/pipeflow.py
+++ b/src/pandapipes/pipeflow.py
@@ -58,13 +58,11 @@ def pipeflow(net, sol_vec=None, **kwargs):
         >>> pipeflow(net, mode="hydraulics")
 
     """
-    local_params = dict(locals())
-
     # Inputs & initialization of variables
     # ------------------------------------------------------------------------------------------
 
     # Init physical constants and options
-    init_options(net, local_params)
+    init_options(net, **kwargs)
     calculation_mode = get_net_option(net, "mode")
 
     # init result tables

--- a/src/pandapipes/test/pipeflow_internals/test_options.py
+++ b/src/pandapipes/test/pipeflow_internals/test_options.py
@@ -136,9 +136,7 @@ def test_mixed_sources(curr_mode):
     modes = {"max_iter_hyd", "max_iter_therm", "max_iter_bidirect"} - {curr_mode}
     opts = {"iter": 5, curr_mode: 10}
 
-    with pytest.warns(UserWarning, match="Overwriting"):
-        _iteration_check(opts)
-
+    _iteration_check(opts)
     assert opts[curr_mode] == 10
     for mode in modes:
         assert opts[mode] == 5

--- a/src/pandapipes/test/pipeflow_internals/test_options.py
+++ b/src/pandapipes/test/pipeflow_internals/test_options.py
@@ -9,6 +9,7 @@ import pytest
 import pandapipes
 import pandapipes.pf.pipeflow_setup
 from pandapipes.pf.pipeflow_setup import PipeflowNotConverged
+from pandapipes.pf.pipeflow_setup import _iteration_check
 from pandapipes.test.pipeflow_internals.test_inservice import create_test_net
 
 
@@ -107,6 +108,50 @@ def test_iter(create_test_net, use_numba):
 
     with pytest.raises(PipeflowNotConverged):
         pandapipes.pipeflow(net, mode='sequential', iter=2)
+
+
+# _iteration_check tests
+
+
+def test_iter_fallback():
+    opts = {"iter": 5}
+    _iteration_check(opts)
+    assert opts == {
+        "iter": 5,
+        "max_iter_hyd": 5,
+        "max_iter_therm": 5,
+        "max_iter_bidirect": 5,
+    }
+
+
+@pytest.mark.parametrize(
+    "curr_mode",
+    [
+        "max_iter_hyd",
+        "max_iter_therm",
+        "max_iter_bidirect",
+    ],
+)
+def test_mixed_sources(curr_mode):
+    modes = {"max_iter_hyd", "max_iter_therm", "max_iter_bidirect"} - {curr_mode}
+    opts = {"iter": 5, curr_mode: 10}
+
+    with pytest.warns(UserWarning, match="Overwriting"):
+        _iteration_check(opts)
+
+    assert opts[curr_mode] == 10
+    for mode in modes:
+        assert opts[mode] == 5
+
+def test_empty_source():
+    opts = {}
+    _iteration_check(opts)
+    assert not opts
+
+def test_unrelated_key():
+    opts = {"unrelated_key": "some_value"}
+    _iteration_check(opts)
+    assert opts == {"unrelated_key": "some_value"}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Improve readability and maintainability of `pipeflow_setup`

This PR simplifies the pipeflow initialization logic by:
1. **Making deepcopy operations explicit and singular**
   - Replaces hidden deepcopies in `_iteration_check` and `_check_mode`
   - Eliminates duplicate copying by centralizing the operation
   
2. **Clarifying option precedence**
   - Uses explicit `{**a, **b}` syntax for option merging
   - Clearly defines overwrite order

3. **Removing redundant parameters**
   - Deletes unused default parameters from `pipeflow` function definition
   - (Parameters were always overwritten by `locals()`)

4. **Applying DRY principle**
   - Replaces repetitive branching in `_iteration_check` with loop logic
   - Reduces code duplication across mode checks

Additional improvements:
- Added tests for `_iteration_check` functionality

---

**Planned follow-up work** (separate PRs):
1. Replace `logging.*` calls with `warnings.warn` for:
   - More appropriate user notifications
   - Single-session message suppression
   - Standard Python warning controls
   
2. Add parameter validation in `init_options` to:
   - Surface incorrect values earlier
   - Provide precise error location
   - Improve debugging feedback