### PR TITLE
Add Plotly/Mapbox plotting with temperature coloring

### DIFF
--- a/src/pandapipes/plotting/colormaps.py
+++ b/src/pandapipes/plotting/colormaps.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016-2023 by University of Kassel and Fraunhofer Institute for Energy Economics
+# and Energy System Technology (IEE), Kassel. All rights reserved.
+
+
+try:
+    from matplotlib.colors import ListedColormap, BoundaryNorm, LinearSegmentedColormap, Normalize, LogNorm
+    MATPLOTLIB_INSTALLED = True
+except ImportError:
+    MATPLOTLIB_INSTALLED = False
+
+import numpy as np
+
+
+def cmap_discrete(cmap_list):
+    """
+    Can be used to create a discrete colormap.
+
+    INPUT:
+        - cmap_list (list) - list of tuples, where each tuple represents one range. Each tuple has
+                             the form of ((from, to), color).
+
+    OUTPUT:
+        - cmap - matplotlib colormap
+
+        - norm - matplotlib norm object
+
+    EXAMPLE:
+        >>> from pandapower.plotting import cmap_discrete, create_line_collection, draw_collections
+        >>> from pandapower.networks import mv_oberrhein
+        >>> net = mv_oberrhein("generation")
+        >>> cmap_list = [((0, 10), "green"), ((10, 30), "yellow"), ((30, 100), "red")]
+        >>> cmap, norm = cmap_discrete(cmap_list)
+        >>> lc = create_line_collection(net, cmap=cmap, norm=norm)
+        >>> draw_collections([lc])
+    """
+    if not MATPLOTLIB_INSTALLED:
+        raise UserWarning("install matplotlib to use this function")
+    cmap_colors = []
+    boundaries = []
+    last_upper = None
+    for (lower, upper), color in cmap_list:
+        if last_upper is not None and lower != last_upper:
+            raise ValueError("Ranges for colormap must be continuous")
+        cmap_colors.append(color)
+        boundaries.append(lower)
+        last_upper = upper
+    boundaries.append(upper)
+    cmap = ListedColormap(cmap_colors)
+    norm = BoundaryNorm(boundaries, cmap.N)
+    return cmap, norm
+
+
+def cmap_continuous(cmap_list):
+    """
+    Can be used to create a continuous colormap.
+
+    INPUT:
+        - cmap_list (list) - list of tuples, where each tuple represents one color. Each tuple has
+                             the form of (center, color). The colorbar is a linear segmentation of
+                             the colors between the centers.
+
+    OUTPUT:
+        - cmap - matplotlib colormap
+
+        - norm - matplotlib norm object
+
+    EXAMPLE:
+        >>> from pandapower.plotting import cmap_continuous, create_bus_collection, draw_collections
+        >>> from pandapower.networks import mv_oberrhein
+        >>> net = mv_oberrhein("generation")
+        >>> cmap_list = [(0.97, "blue"), (1.0, "green"), (1.03, "red")]
+        >>> cmap, norm = cmap_continuous(cmap_list)
+        >>> bc = create_bus_collection(net, size=70, cmap=cmap, norm=norm)
+        >>> draw_collections([bc])
+    """
+    if not MATPLOTLIB_INSTALLED:
+        raise UserWarning("install matplotlib to use this function")
+    min_loading = cmap_list[0][0]
+    max_loading = cmap_list[-1][0]
+    cmap_colors = [((loading-min_loading)/(max_loading - min_loading), color) for
+                 (loading, color) in cmap_list]
+    cmap = LinearSegmentedColormap.from_list('name', cmap_colors)
+    norm = Normalize(min_loading, max_loading)
+    return cmap, norm
+
+
+def cmap_logarithmic(min_value, max_value, colors):
+    """
+        Can be used to create a logarithmic colormap. The colormap itself has a linear segmentation of
+        the given colors. The values however will be matched to the colors based on a logarithmic
+        normalization (c.f. matplotlib.colors.LogNorm for more information on how the logarithmic
+        normalization works).
+
+        \nPlease note: {There are numerous ways of how a logarithmic scale might
+                        be created, the intermediate values on the scale are created automatically based on the minimum
+                        and maximum given values in analogy to the LogNorm. Also, the logarithmic colormap can only be
+                        used with at least 3 colors and increasing values which all have to be above 0.}
+
+        INPUT:
+            **min_value** (float) - the minimum value of the colorbar
+
+            **max_value** (float) - the maximum value for the colorbar
+
+            **colors** (list) - list of colors to be used for the colormap
+
+        OUTPUT:
+            **cmap** - matplotlib colormap
+
+            **norm** - matplotlib norm object
+
+        EXAMPLE:
+
+        >>> from pandapower.plotting import cmap_logarithmic, create_bus_collection, draw_collections
+        >>> from pandapower.networks import mv_oberrhein
+        >>> net = mv_oberrhein("generation")
+        >>> min_value, max_value = 1.0, 1.03
+        >>> colors = ["blue", "green", "red"]
+        >>> cmap, norm = cmap_logarithmic(min_value, max_value, colors)
+        >>> bc = create_bus_collection(net, size=70, cmap=cmap, norm=norm)
+        >>> draw_collections([bc])
+
+    """
+
+    num_values = len(colors)
+    if num_values < 2:
+        raise UserWarning("Cannot create a logarithmic colormap less than 2 colors.")
+    if min_value <= 0:
+        raise UserWarning("The minimum value must be above 0.")
+    if max_value <= min_value:
+        raise UserWarning("The upper bound must be larger than the lower bound.")
+    values = np.arange(num_values + 1)
+    diff = (max_value - min_value) / (num_values - 1)
+    values = (np.log(min_value + values * diff) - np.log(min_value)) \
+             / (np.log(max_value) - np.log(min_value))
+    cmap = LinearSegmentedColormap.from_list("name", list(zip(values, colors)))
+    norm = LogNorm(min_value, max_value)
+    return cmap, norm

--- a/src/pandapipes/plotting/mapbox_plot.py
+++ b/src/pandapipes/plotting/mapbox_plot.py
@@ -1,0 +1,487 @@
+"""
+mapbox_plot.py
+
+This module adds Mapbox‐based (Plotly) plotting functionality to pandapipes.
+It provides helper functions for setting/retrieving the Mapbox token and a
+main function to create an interactive Plotly figure that plots all network
+components on a real map.
+
+Inspired by the pandapower implementation, it supports:
+  • Junctions (from net.junction_geodata)
+  • Pipes – if net.pipe_geodata exists, its “coords” are used;
+      otherwise, the from/to junctions (via net.pipe) are used.
+  • External Grids, Sources, and Sinks – using the junction reference.
+  • Valves – if a dedicated “junction” column exists use it; otherwise compute
+      the midpoint from “from_junction” and “to_junction”.
+  • Pumps – drawn as lines between from/to junctions.
+  • Line‐type components (Heat exchangers, Press controls, Compressors,
+      Flow controls, Heat consumers) – drawn as lines using “from_junction” and “to_junction”.
+      
+New functionality:
+  • Optionally color pipes based on (e.g.) temperature values (from net.res_pipe)
+    and display a colorbar.
+"""
+from pandapipes.plotting import colormaps
+
+import os
+import plotly.graph_objects as go
+import matplotlib.colors as mcolors
+
+# Module‐level variable to hold a user‐defined Mapbox access token.
+_MAPBOX_TOKEN = None
+
+
+def set_mapbox_token(token):
+    """
+    Save the user's Mapbox API token for authenticated access.
+    
+    Parameters
+    ----------
+    token : str
+         A valid Mapbox access token.
+    """
+    global _MAPBOX_TOKEN
+    _MAPBOX_TOKEN = token
+
+
+def _get_mapbox_token():
+    """
+    Retrieve the stored Mapbox token. If none has been set,
+    try reading from the environment variable MAPBOX_ACCESS_TOKEN.
+    
+    Returns
+    -------
+    token : str
+         The Mapbox token (or an empty string if none is available).
+    """
+    global _MAPBOX_TOKEN
+    if _MAPBOX_TOKEN is None:
+        _MAPBOX_TOKEN = os.getenv("MAPBOX_ACCESS_TOKEN", "")
+    return _MAPBOX_TOKEN
+
+
+def _on_map_test(x, y):
+    """
+    Test whether given coordinates (x, y) are plausible geographic coordinates.
+    (Assuming x is longitude and y is latitude.)
+    
+    Parameters
+    ----------
+    x : float
+         Longitude.
+    y : float
+         Latitude.
+         
+    Returns
+    -------
+    bool
+         True if x is between -180 and 180 and y between -90 and 90.
+    """
+    return (-180 <= x <= 180) and (-90 <= y <= 90)
+
+
+def create_mapbox_figure(net, mapbox_access_token=None, map_style="streets", zoom=10,
+                         pipe_temperature_coloring=False, pipe_temperature_field="t_to_k",
+                         pipe_color=None, show_colorbar=False, 
+                         pipe_temperature_colorscale=[[0, "blue"], [1, "red"]]):
+    """
+    Create an interactive Plotly Mapbox figure for a pandapipes network.
+    
+    The function gathers geodata from all network components. For components that
+    do not have dedicated geodata (e.g. sinks, sources, heat exchangers, valves, pumps,
+    compressors), the referenced junction geodata (or midpoints between “from” and “to” nodes)
+    are used.
+    
+    Parameters
+    ----------
+    net : pandapipes network
+         The network object. It is expected that:
+           - net.junction_geodata is a DataFrame containing the junction coordinates.
+           - net.pipe_geodata is optional (if provided, each row should have a "coords" column,
+             a list of coordinate pairs).
+           - Other component tables (net.pipe, net.ext_grid, net.source, net.sink, net.valve,
+             net.pump, net.heat_exchanger, net.press_control, net.compressor, net.flow_control,
+             net.heat_consumer) are available.
+    mapbox_access_token : str, optional
+         A valid Mapbox access token. If None, _get_mapbox_token() is used.
+    map_style : str, optional
+         The Mapbox style (e.g. "streets", "light", "dark", "satellite"). Default is "streets".
+    zoom : int, optional
+         The initial zoom level. Default is 10.
+         
+    Additional parameters for pipe temperature-based coloring:
+    pipe_temperature_coloring : bool, optional
+         If True, pipes are colored based on the temperature value taken from net.res_pipe.
+         (Default: False)
+    pipe_temperature_field : str, optional
+         The field name in net.res_pipe to use for temperature (default: "t_to_k").
+    pipe_color : list or str, optional
+         If provided (and if pipe_temperature_coloring is False), these colors are used for pipes.
+         If a list, it is assumed the ordering corresponds to the pipe indices.
+    show_colorbar : bool, optional
+         If True (and pipe_temperature_coloring is True), a colorbar is added to the figure.
+    pipe_temperature_colorscale : list, optional
+         The colorscale to use for the colorbar (default: [[0, "blue"], [1, "red"]]).
+    
+    Returns
+    -------
+    fig : plotly.graph_objects.Figure
+         The interactive Plotly figure with the network overlaid on a Mapbox basemap.
+    """
+    token = mapbox_access_token if mapbox_access_token is not None else _get_mapbox_token()
+    if not token:
+        print("Warning: No Mapbox access token provided. The map may not render correctly.")
+
+    traces = []
+    center = {"lat": 0, "lon": 0}
+
+    # --- Junctions ---
+    if hasattr(net, "junction_geodata") and net.junction_geodata is not None and not net.junction_geodata.empty:
+        df = net.junction_geodata
+        if "lat" in df.columns and "lon" in df.columns:
+            lat = df["lat"]
+            lon = df["lon"]
+        elif "y" in df.columns and "x" in df.columns:
+            lat = df["y"]
+            lon = df["x"]
+        else:
+            raise ValueError("Junction geodata must have columns 'lat'/'lon' or 'x'/'y'.")
+        center = {"lat": float(lat.mean()), "lon": float(lon.mean())}
+        traces.append(go.Scattermapbox(
+            lon=lon,
+            lat=lat,
+            mode="markers",
+            marker=dict(size=8, color="red"),
+            text=["Junction {}".format(i) for i in df.index],
+            name="Junctions"
+        ))
+    else:
+        print("Warning: No junction geodata available.")
+
+    # --- Pipes ---
+    # If temperature-based coloring is enabled and pipe results are available,
+    # compute the min/max and a colormap.
+    if pipe_temperature_coloring:
+        if hasattr(net, "res_pipe") and net.res_pipe is not None and not net.res_pipe.empty:
+            pipe_temps = net.res_pipe[pipe_temperature_field].values
+            min_temp = float(pipe_temps.min())
+            max_temp = float(pipe_temps.max())
+            from pandapipes.plotting import colormaps
+            cmap, norm = colormaps.cmap_continuous([(min_temp, "blue"), (max_temp, "red")])
+        else:
+            print("Warning: pipe_temperature_coloring is enabled but no pipe results are available. Defaulting to gray.")
+            cmap = None
+            norm = None
+            min_temp = None
+            max_temp = None
+    else:
+        cmap = None
+        norm = None
+        min_temp = None
+        max_temp = None
+
+    # Prefer pipe_geodata if available
+    if hasattr(net, "pipe_geodata") and net.pipe_geodata is not None and not net.pipe_geodata.empty:
+        for idx, row in net.pipe_geodata.iterrows():
+            coords = row.get("coords")
+            if coords is None:
+                continue
+            if isinstance(coords, list) and len(coords) > 0:
+                # Assume each coordinate pair is (x, y) which represents (lon, lat)
+                lon_list, lat_list = zip(*coords)
+                # Determine color for this pipe trace
+                if pipe_temperature_coloring:
+                    if cmap is not None:
+                        try:
+                            temp = net.res_pipe.loc[idx, pipe_temperature_field]
+                        except Exception:
+                            temp = min_temp
+                        color = mcolors.rgb2hex(cmap(norm(temp)))
+                    else:
+                        color = "gray"
+                elif pipe_color is not None:
+                    if isinstance(pipe_color, (list, tuple)):
+                        color = pipe_color[idx] if idx < len(pipe_color) else "gray"
+                    else:
+                        color = pipe_color
+                else:
+                    color = "gray"
+                traces.append(go.Scattermapbox(
+                    lon=lon_list,
+                    lat=lat_list,
+                    mode="lines",
+                    line=dict(width=3, color=color),
+                    name="Pipe {}".format(idx)
+                ))
+    elif hasattr(net, "pipe") and net.pipe is not None and not net.pipe.empty:
+        # Fallback: use junction_geodata via from/to indices
+        for idx, row in net.pipe.iterrows():
+            from_idx = row["from_junction"]
+            to_idx = row["to_junction"]
+            try:
+                if "lat" in net.junction_geodata.columns and "lon" in net.junction_geodata.columns:
+                    lat0 = net.junction_geodata.loc[from_idx, "lat"]
+                    lon0 = net.junction_geodata.loc[from_idx, "lon"]
+                    lat1 = net.junction_geodata.loc[to_idx, "lat"]
+                    lon1 = net.junction_geodata.loc[to_idx, "lon"]
+                elif "y" in net.junction_geodata.columns and "x" in net.junction_geodata.columns:
+                    lat0 = net.junction_geodata.loc[from_idx, "y"]
+                    lon0 = net.junction_geodata.loc[from_idx, "x"]
+                    lat1 = net.junction_geodata.loc[to_idx, "y"]
+                    lon1 = net.junction_geodata.loc[to_idx, "x"]
+                else:
+                    continue
+            except Exception:
+                continue
+            if pipe_temperature_coloring:
+                if cmap is not None:
+                    try:
+                        temp = net.res_pipe.loc[idx, pipe_temperature_field]
+                    except Exception:
+                        temp = min_temp
+                    color = mcolors.rgb2hex(cmap(norm(temp)))
+                else:
+                    color = "gray"
+            elif pipe_color is not None:
+                if isinstance(pipe_color, (list, tuple)):
+                    color = pipe_color[idx] if idx < len(pipe_color) else "gray"
+                else:
+                    color = pipe_color
+            else:
+                color = "gray"
+            traces.append(go.Scattermapbox(
+                lon=[lon0, lon1],
+                lat=[lat0, lat1],
+                mode="lines",
+                line=dict(width=3, color=color),
+                name="Pipe {}".format(idx)
+            ))
+
+    # --- External Grids ---
+    if hasattr(net, "ext_grid") and net.ext_grid is not None and not net.ext_grid.empty:
+        eg_indices = net.ext_grid.junction.values
+        try:
+            coords = net.junction_geodata.loc[eg_indices]
+        except Exception:
+            coords = None
+        if coords is not None and not coords.empty:
+            if "lat" in coords.columns and "lon" in coords.columns:
+                lat = coords["lat"]
+                lon = coords["lon"]
+            elif "y" in coords.columns and "x" in coords.columns:
+                lat = coords["y"]
+                lon = coords["x"]
+            else:
+                lat, lon = [], []
+            traces.append(go.Scattermapbox(
+                lon=lon,
+                lat=lat,
+                mode="markers",
+                marker=dict(size=10, color="orange"),
+                text=["Ext Grid {}".format(i) for i in coords.index],
+                name="External Grids"
+            ))
+
+    # --- Sources ---
+    if hasattr(net, "source") and net.source is not None and not net.source.empty:
+        src_indices = net.source.junction.values
+        try:
+            coords = net.junction_geodata.loc[src_indices]
+        except Exception:
+            coords = None
+        if coords is not None and not coords.empty:
+            if "lat" in coords.columns and "lon" in coords.columns:
+                lat = coords["lat"]
+                lon = coords["lon"]
+            elif "y" in coords.columns and "x" in coords.columns:
+                lat = coords["y"]
+                lon = coords["x"]
+            else:
+                lat, lon = [], []
+            traces.append(go.Scattermapbox(
+                lon=lon,
+                lat=lat,
+                mode="markers",
+                marker=dict(size=10, color="blue"),
+                text=["Source {}".format(i) for i in coords.index],
+                name="Sources"
+            ))
+
+    # --- Sinks ---
+    if hasattr(net, "sink") and net.sink is not None and not net.sink.empty:
+        sink_indices = net.sink.junction.values
+        try:
+            coords = net.junction_geodata.loc[sink_indices]
+        except Exception:
+            coords = None
+        if coords is not None and not coords.empty:
+            if "lat" in coords.columns and "lon" in coords.columns:
+                lat = coords["lat"]
+                lon = coords["lon"]
+            elif "y" in coords.columns and "x" in coords.columns:
+                lat = coords["y"]
+                lon = coords["x"]
+            else:
+                lat, lon = [], []
+            traces.append(go.Scattermapbox(
+                lon=lon,
+                lat=lat,
+                mode="markers",
+                marker=dict(size=10, color="green"),
+                text=["Sink {}".format(i) for i in coords.index],
+                name="Sinks"
+            ))
+
+    # --- Valves ---
+    if hasattr(net, "valve") and net.valve is not None and not net.valve.empty:
+        if "junction" in net.valve.columns:
+            valve_indices = net.valve.junction.values
+            try:
+                coords = net.junction_geodata.loc[valve_indices]
+            except Exception:
+                coords = None
+            if coords is not None and not coords.empty:
+                if "lat" in coords.columns and "lon" in coords.columns:
+                    lat = coords["lat"]
+                    lon = coords["lon"]
+                elif "y" in coords.columns and "x" in coords.columns:
+                    lat = coords["y"]
+                    lon = coords["x"]
+                else:
+                    lat, lon = [], []
+                traces.append(go.Scattermapbox(
+                    lon=lon,
+                    lat=lat,
+                    mode="markers",
+                    marker=dict(size=8, color="cyan"),
+                    text=["Valve {}".format(i) for i in coords.index],
+                    name="Valves"
+                ))
+        elif "from_junction" in net.valve.columns and "to_junction" in net.valve.columns:
+            for idx, row in net.valve.iterrows():
+                from_idx = row["from_junction"]
+                to_idx = row["to_junction"]
+                try:
+                    if "lat" in net.junction_geodata.columns and "lon" in net.junction_geodata.columns:
+                        lat0 = net.junction_geodata.loc[from_idx, "lat"]
+                        lon0 = net.junction_geodata.loc[from_idx, "lon"]
+                        lat1 = net.junction_geodata.loc[to_idx, "lat"]
+                        lon1 = net.junction_geodata.loc[to_idx, "lon"]
+                    elif "y" in net.junction_geodata.columns and "x" in net.junction_geodata.columns:
+                        lat0 = net.junction_geodata.loc[from_idx, "y"]
+                        lon0 = net.junction_geodata.loc[from_idx, "x"]
+                        lat1 = net.junction_geodata.loc[to_idx, "y"]
+                        lon1 = net.junction_geodata.loc[to_idx, "x"]
+                    else:
+                        continue
+                except Exception:
+                    continue
+                mid_lat = (lat0 + lat1) / 2.0
+                mid_lon = (lon0 + lon1) / 2.0
+                traces.append(go.Scattermapbox(
+                    lon=[mid_lon],
+                    lat=[mid_lat],
+                    mode="markers",
+                    marker=dict(size=8, color="cyan"),
+                    text="Valve {}".format(idx),
+                    name="Valves"
+                ))
+
+    # --- Pumps ---
+    if hasattr(net, "pump") and net.pump is not None and not net.pump.empty:
+        for idx, row in net.pump.iterrows():
+            from_idx = row["from_junction"]
+            to_idx = row["to_junction"]
+            try:
+                if "lat" in net.junction_geodata.columns and "lon" in net.junction_geodata.columns:
+                    lat0 = net.junction_geodata.loc[from_idx, "lat"]
+                    lon0 = net.junction_geodata.loc[from_idx, "lon"]
+                    lat1 = net.junction_geodata.loc[to_idx, "lat"]
+                    lon1 = net.junction_geodata.loc[to_idx, "lon"]
+                elif "y" in net.junction_geodata.columns and "x" in net.junction_geodata.columns:
+                    lat0 = net.junction_geodata.loc[from_idx, "y"]
+                    lon0 = net.junction_geodata.loc[from_idx, "x"]
+                    lat1 = net.junction_geodata.loc[to_idx, "y"]
+                    lon1 = net.junction_geodata.loc[to_idx, "x"]
+                else:
+                    continue
+            except Exception:
+                continue
+            traces.append(go.Scattermapbox(
+                lon=[lon0, lon1],
+                lat=[lat0, lat1],
+                mode="lines",
+                line=dict(width=3, color="purple", dash="dot"),
+                name="Pump {}".format(idx)
+            ))
+
+    # --- Other line-type components ---
+    def add_line_component(component_name, color):
+        if hasattr(net, component_name) and getattr(net, component_name) is not None and not getattr(net, component_name).empty:
+            comp = getattr(net, component_name)
+            for idx, row in comp.iterrows():
+                if "from_junction" in row and "to_junction" in row:
+                    from_idx = row["from_junction"]
+                    to_idx = row["to_junction"]
+                    try:
+                        if "lat" in net.junction_geodata.columns and "lon" in net.junction_geodata.columns:
+                            lat0 = net.junction_geodata.loc[from_idx, "lat"]
+                            lon0 = net.junction_geodata.loc[from_idx, "lon"]
+                            lat1 = net.junction_geodata.loc[to_idx, "lat"]
+                            lon1 = net.junction_geodata.loc[to_idx, "lon"]
+                        elif "y" in net.junction_geodata.columns and "x" in net.junction_geodata.columns:
+                            lat0 = net.junction_geodata.loc[from_idx, "y"]
+                            lon0 = net.junction_geodata.loc[from_idx, "x"]
+                            lat1 = net.junction_geodata.loc[to_idx, "y"]
+                            lon1 = net.junction_geodata.loc[to_idx, "x"]
+                        else:
+                            continue
+                    except Exception:
+                        continue
+                    traces.append(go.Scattermapbox(
+                        lon=[lon0, lon1],
+                        lat=[lat0, lat1],
+                        mode="lines",
+                        line=dict(width=3, color=color),
+                        name="{} {}".format(component_name.capitalize(), idx)
+                    ))
+    add_line_component("heat_exchanger", color="brown")
+    add_line_component("press_control", color="pink")
+    add_line_component("compressor", color="black")
+    add_line_component("flow_control", color="orange")
+    add_line_component("heat_consumer", color="yellow")
+
+    if pipe_temperature_coloring and show_colorbar and min_temp is not None and max_temp is not None:
+        traces.append(go.Scattermapbox(
+            lon=[center["lon"]],
+            lat=[center["lat"]],
+            mode="markers",
+            marker=dict(
+                size=0,
+                color=[min_temp],  # Dummy value
+                colorscale=pipe_temperature_colorscale,
+                cmin=min_temp,
+                cmax=max_temp,
+                colorbar=dict(
+                    title="Pipe Temperature (K)"
+                    
+                ),
+                showscale=True
+            ),
+            showlegend=False,
+            hoverinfo="none"
+        ))
+
+    layout = go.Layout(
+        mapbox=dict(
+            accesstoken=token,
+            style=map_style,
+            center=center,
+            zoom=zoom
+        ),
+        margin={"l": 0, "r": 0, "t": 0, "b": 0},
+        showlegend=True
+    )
+    
+    fig = go.Figure(data=traces, layout=layout)
+    return fig

--- a/src/pandapipes/plotting/simple_plot.py
+++ b/src/pandapipes/plotting/simple_plot.py
@@ -32,84 +32,54 @@ def simple_plot(net, respect_valves=False, respect_in_service=True, pipe_width=2
                 heat_consumer_size=1.0, scale_size=True, junction_color="r", pipe_color='silver',
                 ext_grid_color='orange', valve_color='silver', pump_color='silver', heat_exchanger_color='silver',
                 pressure_control_color='silver', compressor_color='silver', flow_control_color='silver',
-                heat_consumer_color='silver',library="igraph", show_plot=True, ax=None, **kwargs):
+                heat_consumer_color='silver', library="igraph", show_plot=True, ax=None,
+                use_mapbox=False, mapbox_access_token=None, map_style="streets", zoom=10,
+                # New parameters for pipe temperature-based coloring:
+                pipe_temperature_coloring=False, pipe_temperature_field="t_to_k",
+                show_colorbar=False, pipe_temperature_colorscale=[[0, "blue"], [1, "red"]],
+                **kwargs):
     """
     Plots a pandapipes network as simple as possible. If no geodata is available, artificial
-    geodata is generated. For advanced plotting see
-    the `tutorial <https://github.com/e2nIEE/pandapipes/blob/master/tutorials/simple_plot.ipynb>`_.
-
-    :param net: The pandapipes format network.
-    :type net: pandapipesNet
-    :param respect_valves: Respect valves if artificial geodata is created. \
-            Note: This Flag is ignored if plot_line_switches is True
-    :type respect_valves: bool default False
-    :param respect_in_service: Respect only components which are in service.
-    :type respect_in_service: bool default True
-    :param pipe_width: Width of pipes
-    :type pipe_width: float, default 5.0
-    :param junction_size: Relative size of junctions to plot. The value junction_size is multiplied\
-            with mean_distance_between_buses, which equals the distance between the max geoocord\
-            and the min divided by 200
-    :type junction_size: float, default 1.0
-    :param ext_grid_size: Relative size of ext_grids to plot. See bus sizes for details. Note: \
-            ext_grids are plottet as rectangles
-    :type ext_grid_size: float, default 1.0
-    :param plot_sinks: Flag to decide whether sink symbols should be drawn.
-    :type plot_sinks: bool, default False
-    :param plot_sources: Flag to decide whether source symbols should be drawn.
-    :type plot_sources: bool, default False
-    :param sink_size: Relative size of sinks to plot.
-    :type sink_size: float, default 1.0
-    :param source_size: Relative size of sources to plot.
-    :type source_size: float, default 1.0
-    :param valve_size: Relative size of valves to plot.
-    :type valve_size: float, default 1.0
-    :param pump_size: Relative size of pumps to plot.
-    :type pump_size: float, default 1.0
-    :param heat_exchanger_size: Relative size of heat_exchanger to plot.
-    :type heat_exchanger_size: float, default 1.0
-    :param pressure_control_size: Relative size of pres_control to plot.
-    :type pressure_control_size: float, default 1.0
-    :param compressor_size: Relative size of compressor to plot.
-    :type compressor_size: float, default 1.0
-    :param flow_control_size: Relative size of flow_control to plot.
-    :type flow_control_size: float, default 1.0
-    :param heat_consumer_size: Relative size of heat_consumer to plot.
-    :type heat_consumer_size: float, default 1.0
-    :param scale_size: Flag if junction_size, ext_grid_size, valve_size- and distance will be \
-            scaled with respect to grid mean distances
-    :type scale_size: bool, default True
-    :param junction_color: Junction Color. See also matplotlib or seaborn documentation on how to\
-            choose colors.
-    :type junction_color: str, tuple, default "r"
-    :param pipe_color: Pipe color
-    :type pipe_color: str, tuple, default "silver"
-    :param ext_grid_color: External grid color
-    :type ext_grid_color: str, tuple, default "orange"
-    :param valve_color: Valve Color.
-    :type valve_color: str, tuple, default "silver"
-    :param pump_color: Pump Color.
-    :type pump_color: str, tuple, default "silver"
-    :param heat_exchanger_color: Heat Exchanger Color.
-    :type heat_exchanger_color: str, tuple, default "silver"
-    :param pressure_control_color: Pressure Control Color.
-    :type pressure_control_color: str, tuple, default "silver"
-    :param compressor_color: Compressor Color.
-    :type compressor_color: str, tuple, default "silver"
-    :param flow_control_color: Flow Control Color.
-    :type flow_control_color: str, tuple, default "silver"
-    :param heat_consumer_color: heat_consumer Color.
-    :type heat_consumer_color: str, tuple, default "silver"
-    :param library: Library name to create generic coordinates (case of missing geodata). Choose\
-            "igraph" to use igraph package or "networkx" to use networkx package.
-    :type library: str, default "igraph"
-    :param show_plot: If True, show plot at the end of plotting
-    :type show_plot: bool, default True
-    :param ax: matplotlib axis to plot to
-    :type ax: object, default None
-    :return: ax - Axes of figure
-
+    geodata is generated. For advanced plotting see the tutorial.
+    
+    Additional parameters:
+      - use_mapbox : bool
+            If True, plot the network on an interactive Mapbox map using Plotly.
+      - mapbox_access_token : str
+            Mapbox token to use. If None, the environment variable or stored token is used.
+      - map_style : str
+            Mapbox style (e.g. "streets", "light", "dark", "satellite").
+      - zoom : int
+            Initial zoom level for the Mapbox plot.
+      - pipe_temperature_coloring : bool
+            If True, pipes are colored based on the temperature values in net.res_pipe.
+      - pipe_temperature_field : str
+            The field in net.res_pipe to use for temperature (default: "t_to_k").
+      - show_colorbar : bool
+            If True and pipe_temperature_coloring is enabled, a colorbar is shown.
+      - pipe_temperature_colorscale : list
+            The colorscale for the colorbar (default: [[0, "blue"], [1, "red"]]).
+            
+    All other parameters remain as in the original implementation.
     """
+    if use_mapbox:
+        from pandapipes.plotting import mapbox_plot
+        fig = mapbox_plot.create_mapbox_figure(
+            net,
+            mapbox_access_token=mapbox_access_token,
+            map_style=map_style,
+            zoom=zoom,
+            pipe_temperature_coloring=pipe_temperature_coloring,
+            pipe_temperature_field=pipe_temperature_field,
+            pipe_color=pipe_color,
+            show_colorbar=show_colorbar,
+            pipe_temperature_colorscale=pipe_temperature_colorscale
+        )
+        if show_plot:
+            fig.show()
+        return fig
+
+    # --- Original matplotlib-based plotting ---
     collections = create_simple_collections(net,
                                             respect_valves=respect_valves,
                                             respect_in_service=respect_in_service,
@@ -141,7 +111,7 @@ def simple_plot(net, respect_valves=False, respect_in_service=True, pipe_width=2
                                             library=library,
                                             as_dict=False, **kwargs)
     ax = draw_collections(collections, ax=ax)
-
+    
     if show_plot:
         plt.show()
     return ax


### PR DESCRIPTION
This pull request adds a new way to plot pandapipes networks using Mapbox and Plotly, similar to how it's done in pandapower.

What's added:

A new function create_mapbox_figure(net, ...) in mapbox_plot.py to show the network on a Mapbox map.

It can plot junctions, pipes, external grids, pumps, valves, sources, sinks, and more.

You can color the pipes based on temperature results from net.res_pipe by setting pipe_temperature_coloring=True.

A colorbar is also shown if show_colorbar=True.

The Mapbox access token can be set using set_mapbox_token() or the MAPBOX_ACCESS_TOKEN environment variable.

How to use:
To use Mapbox plotting, just call simple_plot(net, use_mapbox=True, mapbox_access_token="your_token").

Let me know if anything should be changed or improved.