### PR TITLE
Make "mode" a Enum

### DIFF
--- a/src/pandapipes/component_models/abstract_models/base_component.py
+++ b/src/pandapipes/component_models/abstract_models/base_component.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 from pandapipes.component_models.component_toolbox import init_results_element
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -33,7 +34,7 @@ class Component:
         return res_table
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 

--- a/src/pandapipes/component_models/abstract_models/base_component.py
+++ b/src/pandapipes/component_models/abstract_models/base_component.py
@@ -36,17 +36,18 @@ class Component:
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
-        :param branch_results:
-        :type branch_results:
-        :param mode:
-        :type mode:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
         raise NotImplementedError
 

--- a/src/pandapipes/component_models/abstract_models/branch_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_models.py
@@ -13,6 +13,7 @@ from pandapipes.idx_branch import (
 )
 from pandapipes.pf.pipeflow_setup import get_net_option
 from pandapipes.pf.pipeflow_setup import get_table_number, get_lookup
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -99,5 +100,5 @@ class BranchComponent(Component):
         return branch_component_pit, node_pit
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/branch_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_models.py
@@ -101,4 +101,18 @@ class BranchComponent(Component):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
@@ -195,6 +195,20 @@ class BranchWInternalsComponent(BranchComponent):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         raise NotImplementedError
 
     @classmethod

--- a/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
@@ -9,6 +9,7 @@ from pandapipes.component_models.component_toolbox import set_entry_check_repeat
 from pandapipes.idx_branch import ACTIVE, ELEMENT_IDX, D, LOSS_COEFFICIENT as LC, AREA
 from pandapipes.idx_node import L, node_cols
 from pandapipes.pf.pipeflow_setup import add_table_lookup, get_lookup, get_table_number, get_net_option
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -193,7 +194,7 @@ class BranchWInternalsComponent(BranchComponent):
         return branch_w_internals_pit, node_pit
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         raise NotImplementedError
 
     @classmethod

--- a/src/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
@@ -9,6 +9,7 @@ from pandapipes.idx_branch import (FROM_NODE, TO_NODE, TOUTINIT, ELEMENT_IDX, AC
                                    D, AREA)
 from pandapipes.idx_node import TINIT as TINIT_NODE
 from pandapipes.pf.pipeflow_setup import add_table_lookup, get_net_option, get_lookup
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -113,5 +114,5 @@ class BranchWOInternalsComponent(BranchComponent):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_wo_internals_models.py
@@ -115,4 +115,18 @@ class BranchWOInternalsComponent(BranchComponent):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/circulation_pump.py
+++ b/src/pandapipes/component_models/abstract_models/circulation_pump.py
@@ -11,6 +11,7 @@ from pandapipes.idx_node import MDOTSLACKINIT, VAR_MASS_SLACK, JAC_DERIV_MSL, NO
 from pandapipes.pf.pipeflow_setup import get_fluid, get_lookup
 from pandapipes.pf.internals_toolbox import get_from_nodes_corrected
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -142,7 +143,7 @@ class CirculationPump(BranchWOInternalsComponent):
 
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 
@@ -169,7 +170,7 @@ class CirculationPump(BranchWOInternalsComponent):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd, required_results_ht,
-                                                 cls.table_name(), mode)
+                                                 cls.table_name(), sim_mode)
 
         res_table = net["res_" + cls.table_name()]
 

--- a/src/pandapipes/component_models/abstract_models/circulation_pump.py
+++ b/src/pandapipes/component_models/abstract_models/circulation_pump.py
@@ -145,17 +145,18 @@ class CirculationPump(BranchWOInternalsComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param mode:
-        :type mode:
-        :param branch_results:
-        :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
         node_pit = net['_pit']['node']
         branch_pit = net['_pit']['branch']

--- a/src/pandapipes/component_models/abstract_models/const_flow_models.py
+++ b/src/pandapipes/component_models/abstract_models/const_flow_models.py
@@ -53,17 +53,18 @@ class ConstFlow(NodeElementComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param mode:
-        :type mode:
-        :param branch_results:
-        :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
         res_table = net["res_" + cls.table_name()]
 

--- a/src/pandapipes/component_models/abstract_models/const_flow_models.py
+++ b/src/pandapipes/component_models/abstract_models/const_flow_models.py
@@ -8,7 +8,7 @@ from pandapipes.component_models.abstract_models.node_element_models import Node
 from pandapipes.idx_node import LOAD, ELEMENT_IDX
 from pandapipes.pf.internals_toolbox import _sum_by_group
 from pandapipes.pf.pipeflow_setup import get_lookup, get_net_option
-
+from pandapipes.enums import SimMode
 
 class ConstFlow(NodeElementComponent):
 
@@ -51,7 +51,7 @@ class ConstFlow(NodeElementComponent):
         node_pit[index, LOAD] += loads_sum
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 

--- a/src/pandapipes/component_models/abstract_models/node_element_models.py
+++ b/src/pandapipes/component_models/abstract_models/node_element_models.py
@@ -53,4 +53,18 @@ class NodeElementComponent(Component):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/node_element_models.py
+++ b/src/pandapipes/component_models/abstract_models/node_element_models.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 from pandapipes.component_models.abstract_models.base_component import Component
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -51,5 +52,5 @@ class NodeElementComponent(Component):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/node_models.py
+++ b/src/pandapipes/component_models/abstract_models/node_models.py
@@ -3,6 +3,7 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 from pandapipes.component_models.abstract_models.base_component import Component
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -66,5 +67,5 @@ class NodeComponent(Component):
         raise NotImplementedError
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         raise NotImplementedError

--- a/src/pandapipes/component_models/abstract_models/node_models.py
+++ b/src/pandapipes/component_models/abstract_models/node_models.py
@@ -68,4 +68,18 @@ class NodeComponent(Component):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         raise NotImplementedError

--- a/src/pandapipes/component_models/component_toolbox.py
+++ b/src/pandapipes/component_models/component_toolbox.py
@@ -13,6 +13,7 @@ from pandapipes.idx_node import (EXT_GRID_OCCURENCE, EXT_GRID_OCCURENCE_T,
                                  PINIT, NODE_TYPE, P, TINIT, NODE_TYPE_T, T, LOAD)
 from pandapipes.pf.pipeflow_setup import get_net_option, get_lookup
 from pandapipes.pf.internals_toolbox import _sum_by_group
+from pandapipes.enums import PhysDomain, SimMode
 
 
 def get_internal_lookup_structure(internals, table_name, internal_elements, start=0):
@@ -209,7 +210,7 @@ def standard_branch_wo_internals_result_lookup(net):
     return required_results_hyd, required_results_ht
 
 
-def get_component_array(net, component_name, component_type="branch", mode='hydraulics', only_active=True):
+def get_component_array(net, component_name, component_type="branch", domain: PhysDomain = PhysDomain.HYD, only_active=True):
     """
     Returns the internal array of a component.
 
@@ -227,7 +228,7 @@ def get_component_array(net, component_name, component_type="branch", mode='hydr
     if not only_active:
         return net["_pit"]["components"][component_name]
     f_all, t_all = get_lookup(net, component_type, "from_to")[component_name]
-    in_service_elm = get_lookup(net, component_type, "active_%s"%mode)[f_all:t_all]
+    in_service_elm = get_lookup(net, component_type, "active_%s" % domain)[f_all:t_all]
     return net["_pit"]["components"][component_name][in_service_elm]
 
 

--- a/src/pandapipes/component_models/component_toolbox.py
+++ b/src/pandapipes/component_models/component_toolbox.py
@@ -220,6 +220,8 @@ def get_component_array(net, component_name, component_type="branch", domain: Ph
     :type component_name: str
     :param component_type: Type of component that is considered ("branch" or "node")
     :type component_type: str, default "branch"
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain, default PhysDomain.HYD
     :param only_active: If True, only return entries of active elements (included in _active_pit)
     :type only_active: bool
     :return: component_array - internal array of the component

--- a/src/pandapipes/component_models/ext_grid_component.py
+++ b/src/pandapipes/component_models/ext_grid_component.py
@@ -69,17 +69,18 @@ class ExtGrid(NodeElementComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param branch_results:
-        :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
-        :param mode:
-        :type mode:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
         ext_grids = net[cls.table_name()]
 

--- a/src/pandapipes/component_models/ext_grid_component.py
+++ b/src/pandapipes/component_models/ext_grid_component.py
@@ -9,6 +9,7 @@ from pandapipes.component_models.abstract_models.node_element_models import Node
 from pandapipes.component_models.component_toolbox import set_fixed_node_entries
 from pandapipes.pf.pipeflow_setup import get_lookup
 from pandapipes.idx_node import MDOTSLACKINIT, VAR_MASS_SLACK, JAC_DERIV_MSL
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -66,7 +67,7 @@ class ExtGrid(NodeElementComponent):
         return ext_grids, p_values
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 

--- a/src/pandapipes/component_models/flow_control_component.py
+++ b/src/pandapipes/component_models/flow_control_component.py
@@ -13,6 +13,7 @@ from pandapipes.component_models.junction_component import Junction
 from pandapipes.idx_branch import (JAC_DERIV_DP, JAC_DERIV_DP1, JAC_DERIV_DM, MDOTINIT, LOAD_VEC_BRANCHES,
                                    FLOW_RETURN_CONNECT)
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 
 class FlowControlComponent(BranchWOInternalsComponent):
@@ -86,11 +87,11 @@ class FlowControlComponent(BranchWOInternalsComponent):
         fc_branch_pit[active, LOAD_VEC_BRANCHES] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,
-                                                 required_results_ht, cls.table_name(), mode)
+                                                 required_results_ht, cls.table_name(), sim_mode)
 
     @classmethod
     def get_component_input(cls):

--- a/src/pandapipes/component_models/flow_control_component.py
+++ b/src/pandapipes/component_models/flow_control_component.py
@@ -88,6 +88,20 @@ class FlowControlComponent(BranchWOInternalsComponent):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,

--- a/src/pandapipes/component_models/heat_consumer_component.py
+++ b/src/pandapipes/component_models/heat_consumer_component.py
@@ -16,6 +16,7 @@ from pandapipes.pf.internals_toolbox import get_from_nodes_corrected
 from pandapipes.pf.pipeflow_setup import get_lookup
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
 from pandapipes.properties.properties_toolbox import get_branch_cp
+from pandapipes.enums import SimMode, PhysDomain
 
 try:
     import pandaplan.core.pplog as logging
@@ -181,7 +182,7 @@ class HeatConsumer(BranchWOInternalsComponent):
     def adaption_before_derivatives_thermal(cls, net, branch_pit, node_pit, idx_lookups, options):
         f, t = idx_lookups[cls.table_name()]
         hc_pit = branch_pit[f:t, :]
-        consumer_array = get_component_array(net, cls.table_name(), mode='heat_transfer')
+        consumer_array = get_component_array(net, cls.table_name(), domain=PhysDomain.HEAT)
         mask = consumer_array[:, cls.MODE] == cls.MF_DT
         if np.any(mask):
             cp = get_branch_cp(get_fluid(net), node_pit, hc_pit)
@@ -201,7 +202,7 @@ class HeatConsumer(BranchWOInternalsComponent):
     def adaption_after_derivatives_thermal(cls, net, branch_pit, node_pit, idx_lookups, options):
         f, t = idx_lookups[cls.table_name()]
         hc_pit = branch_pit[f:t, :]
-        consumer_array = get_component_array(net, cls.table_name(), mode='heat_transfer')
+        consumer_array = get_component_array(net, cls.table_name(), domain=PhysDomain.HEAT)
 
         mask= consumer_array[:, cls.MODE] == cls.QE_TR
         if np.any(mask):
@@ -247,7 +248,7 @@ class HeatConsumer(BranchWOInternalsComponent):
         return output, True
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
 
         :param net:
@@ -264,7 +265,7 @@ class HeatConsumer(BranchWOInternalsComponent):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd, required_results_ht,
-            cls.table_name(), mode)
+            cls.table_name(), sim_mode)
 
         node_pit = net['_pit']['node']
         branch_pit = net['_pit']['branch']

--- a/src/pandapipes/component_models/heat_consumer_component.py
+++ b/src/pandapipes/component_models/heat_consumer_component.py
@@ -250,17 +250,18 @@ class HeatConsumer(BranchWOInternalsComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param net:
-        :type net:
-        :param options:
-        :type options:
-        :param branch_results:
-        :type branch_results:
-        :param mode:
-        :type mode:
-        :return:
-        :rtype:
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
         """
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 

--- a/src/pandapipes/component_models/heat_exchanger_component.py
+++ b/src/pandapipes/component_models/heat_exchanger_component.py
@@ -67,8 +67,8 @@ class HeatExchanger(BranchWOInternalsComponent):
         :type options: dict
         :param branch_results: important branch results
         :type branch_results: dict
-        :param mode: simulation mode
-        :type mode: str
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
         :rtype: None
         """

--- a/src/pandapipes/component_models/heat_exchanger_component.py
+++ b/src/pandapipes/component_models/heat_exchanger_component.py
@@ -12,6 +12,7 @@ from pandapipes.component_models.junction_component import Junction
 from pandapipes.idx_branch import QEXT, D, AREA, LOSS_COEFFICIENT as LC
 from pandapipes.pf.pipeflow_setup import get_fluid
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -56,7 +57,7 @@ class HeatExchanger(BranchWOInternalsComponent):
         heat_exchanger_pit[:, QEXT] = net[cls.table_name()].qext_w.values
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Class method to extract pipeflow results from the internal structure into the results table.
 
@@ -74,7 +75,7 @@ class HeatExchanger(BranchWOInternalsComponent):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,
-                                                 required_results_ht, cls.table_name(), mode)
+                                                 required_results_ht, cls.table_name(), sim_mode)
 
     @classmethod
     def get_component_input(cls):

--- a/src/pandapipes/component_models/junction_component.py
+++ b/src/pandapipes/component_models/junction_component.py
@@ -100,19 +100,18 @@ class Junction(NodeComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param mode:
-        :type mode:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
-        :param branch_results:
-        :type branch_results:
-        :param mode:
-        :type mode:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
         res_table = net["res_" + cls.table_name()]
 

--- a/src/pandapipes/component_models/junction_component.py
+++ b/src/pandapipes/component_models/junction_component.py
@@ -15,7 +15,7 @@ from pandapipes.idx_node import L, ELEMENT_IDX, PINIT, node_cols, HEIGHT, TINIT,
 from pandapipes.pf.pipeflow_setup import add_table_lookup, get_table_number, \
     get_lookup
 from pandapipes.pf.pipeflow_setup import get_net_option
-
+from pandapipes.enums import SimMode
 
 class Junction(NodeComponent):
     """
@@ -98,7 +98,7 @@ class Junction(NodeComponent):
             junction_pit[:, TINIT_OLD] = junction_pit[:, TINIT]
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 
@@ -129,7 +129,7 @@ class Junction(NodeComponent):
         f, t = get_lookup(net, "node", "from_to")[cls.table_name()]
         junction_pit = net["_pit"]["node"][f:t, :]
 
-        if mode in ["hydraulics", "sequential", "bidirectional"]:
+        if sim_mode in {SimMode.HYD, SimMode.SEQ, SimMode.BIDIR}:
             junctions_connected_hydraulic = get_lookup(net, "node", "active_hydraulics")[f:t]
 
             if np.any(junction_pit[junctions_connected_hydraulic, PINIT] < 0):

--- a/src/pandapipes/component_models/pipe_component.py
+++ b/src/pandapipes/component_models/pipe_component.py
@@ -16,6 +16,7 @@ from pandapipes.idx_node import (TINIT as TINIT_NODE, HEIGHT, PINIT, PAMB, ACTIV
 from pandapipes.pf.pipeflow_setup import get_fluid, get_lookup, get_net_option
 from pandapipes.pf.result_extraction import extract_branch_results_with_internals, \
     extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -154,7 +155,7 @@ class Pipe(BranchWInternalsComponent):
             pipe_pit[:, T_OUT_OLD] = pipe_pit[:, TOUTINIT]
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         res_nodes_from_hyd = [("p_from_bar", "p_from"), ("mdot_from_kg_per_s", "mf_from")]
         res_nodes_from_ht = [("t_from_k", "temp_from")]
         res_nodes_to_hyd = [("p_to_bar", "p_to"), ("mdot_to_kg_per_s", "mf_to")]
@@ -172,12 +173,12 @@ class Pipe(BranchWInternalsComponent):
         if np.any(cls.get_internal_node_number(net) > 0):
             extract_branch_results_with_internals(net, branch_results, cls.table_name(), res_nodes_from_hyd,
                 res_nodes_from_ht, res_nodes_to_hyd, res_nodes_to_ht, res_mean_hyd, res_branch_ht, [],
-                cls.internal_node_name(), mode)
+                cls.internal_node_name(), sim_mode)
         else:
             required_results_hyd = res_nodes_from_hyd + res_nodes_to_hyd + res_mean_hyd
             required_results_ht = res_nodes_from_ht + res_nodes_to_ht + res_branch_ht
             extract_branch_results_without_internals(net, branch_results, required_results_hyd, required_results_ht,
-                cls.table_name(), mode)
+                cls.table_name(), sim_mode)
 
     @classmethod
     def get_internal_results(cls, net, pipe):

--- a/src/pandapipes/component_models/pipe_component.py
+++ b/src/pandapipes/component_models/pipe_component.py
@@ -156,6 +156,20 @@ class Pipe(BranchWInternalsComponent):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         res_nodes_from_hyd = [("p_from_bar", "p_from"), ("mdot_from_kg_per_s", "mf_from")]
         res_nodes_from_ht = [("t_from_k", "temp_from")]
         res_nodes_to_hyd = [("p_to_bar", "p_to"), ("mdot_to_kg_per_s", "mf_to")]

--- a/src/pandapipes/component_models/pressure_control_component.py
+++ b/src/pandapipes/component_models/pressure_control_component.py
@@ -82,19 +82,19 @@ class PressureControlComponent(BranchWOInternalsComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param mode:
-        :type mode:
-        :param branch_results:
-        :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
-
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,

--- a/src/pandapipes/component_models/pressure_control_component.py
+++ b/src/pandapipes/component_models/pressure_control_component.py
@@ -15,6 +15,7 @@ from pandapipes.idx_node import PINIT, NODE_TYPE, PC as PC_NODE
 from pandapipes.pf.pipeflow_setup import get_lookup
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
 from pandapipes.properties.fluids import get_fluid
+from pandapipes.enums import SimMode
 
 
 class PressureControlComponent(BranchWOInternalsComponent):
@@ -79,7 +80,7 @@ class PressureControlComponent(BranchWOInternalsComponent):
         press_pit[pc_branch, JAC_DERIV_DM] = 0
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 
@@ -97,7 +98,7 @@ class PressureControlComponent(BranchWOInternalsComponent):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,
-                                                 required_results_ht, cls.table_name(), mode)
+                                                 required_results_ht, cls.table_name(), sim_mode)
 
         res_table = net["res_" + cls.table_name()]
         f, t = get_lookup(net, "branch", "from_to")[cls.table_name()]

--- a/src/pandapipes/component_models/pump_component.py
+++ b/src/pandapipes/component_models/pump_component.py
@@ -125,19 +125,19 @@ class Pump(BranchWOInternalsComponent):
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
-        Function that extracts certain results.
+        Class method to extract pipeflow results from the internal structure into the results table.
 
-        :param branch_results:
-        :type branch_results:
         :param net: The pandapipes network
         :type net: pandapipesNet
-        :param options:
-        :type options:
-        :param mode:
-        :type mode:
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
         :return: No Output.
+        :rtype: None
         """
-
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
         required_results_hyd.extend([("deltap_bar", "pl")])
 

--- a/src/pandapipes/component_models/pump_component.py
+++ b/src/pandapipes/component_models/pump_component.py
@@ -20,6 +20,7 @@ from pandapipes.idx_branch import MDOTINIT, AREA, LOSS_COEFFICIENT as LC, FROM_N
 from pandapipes.idx_node import PINIT, PAMB, TINIT as TINIT_NODE
 from pandapipes.pf.pipeflow_setup import get_fluid, get_net_option, get_lookup
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -122,7 +123,7 @@ class Pump(BranchWOInternalsComponent):
             pump_branch_pit[:, PL] = pl
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         """
         Function that extracts certain results.
 
@@ -141,7 +142,7 @@ class Pump(BranchWOInternalsComponent):
         required_results_hyd.extend([("deltap_bar", "pl")])
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd,
-                                                 required_results_ht, cls.table_name(), mode)
+                                                 required_results_ht, cls.table_name(), sim_mode)
 
         calc_compr_pow = options['calc_compression_power']
         if calc_compr_pow:

--- a/src/pandapipes/component_models/valve_component.py
+++ b/src/pandapipes/component_models/valve_component.py
@@ -154,6 +154,20 @@ class Valve(BranchWInternalsComponent):
 
     @classmethod
     def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
+        """
+        Class method to extract pipeflow results from the internal structure into the results table.
+
+        :param net: The pandapipes network
+        :type net: pandapipesNet
+        :param options: pipeflow options
+        :type options: dict
+        :param branch_results: important branch results
+        :type branch_results: dict
+        :param sim_mode: Simulation mode determining which results to extract.
+        :type sim_mode: SimMode
+        :return: No Output.
+        :rtype: None
+        """
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         required_results_hyd.extend([("v_mean_m_per_s", "v_mps"), ("lambda", "lambda"), ("reynolds", "reynolds")])

--- a/src/pandapipes/component_models/valve_component.py
+++ b/src/pandapipes/component_models/valve_component.py
@@ -12,6 +12,7 @@ from pandapipes.idx_branch import LENGTH, K, TEXT, ALPHA, FROM_NODE, TO_NODE, TO
 from pandapipes.idx_node import TINIT as TINIT_NODE, HEIGHT, PINIT, ACTIVE as ACTIVE_ND, PAMB, TINIT_OLD
 from pandapipes.pf.pipeflow_setup import get_fluid, get_net_option, get_lookup
 from pandapipes.pf.result_extraction import extract_branch_results_without_internals
+from pandapipes.enums import SimMode
 
 
 class Valve(BranchWInternalsComponent):
@@ -152,7 +153,7 @@ class Valve(BranchWInternalsComponent):
                 ("diameter_m", "f8"), ("opened", "bool"), ("loss_coefficient", "f8"), ("type", dtype(object))]
 
     @classmethod
-    def extract_results(cls, net, options, branch_results, mode):
+    def extract_results(cls, net, options, branch_results, sim_mode: SimMode):
         required_results_hyd, required_results_ht = standard_branch_wo_internals_result_lookup(net)
 
         required_results_hyd.extend([("v_mean_m_per_s", "v_mps"), ("lambda", "lambda"), ("reynolds", "reynolds")])
@@ -161,7 +162,7 @@ class Valve(BranchWInternalsComponent):
             required_results_hyd.extend([("v_from_m_per_s", "v_gas_from"), ("v_to_m_per_s", "v_gas_to")])
 
         extract_branch_results_without_internals(net, branch_results, required_results_hyd, required_results_ht,
-                                                 cls.table_name(), mode)
+                                                 cls.table_name(), sim_mode)
 
     @classmethod
     def get_result_table(cls, net):

--- a/src/pandapipes/converter/stanet/preparing_steps.py
+++ b/src/pandapipes/converter/stanet/preparing_steps.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pandapipes
 from pandapipes.converter.stanet.table_creation import CLIENT_TYPES_OF_NODES
 from pandapipes.properties.fluids import FluidPropertySutherland, _add_fluid_to_net
+from pandapipes.enums import SimMode
 
 try:
     from shapely.geometry import Point, LineString
@@ -182,8 +183,8 @@ def get_net_params(net, stored_data):
     net_params["t_sutherland"] = net_data.at[0, "TS"]
     net_params["t0_sutherland"] = net_data.at[0, "T0"]
     net_params["calculate_temp"] = str(net_data.at[0, "TEMPCALC"]) == "J"
-    pp_calc_mode = "sequential" if net_params["calculate_temp"] else "hydraulics"
-    pandapipes.set_user_pf_options(net, mode=pp_calc_mode)
+    pp_calc_mode = SimMode.SEQ if net_params["calculate_temp"] else SimMode.HYD
+    pandapipes.set_user_pf_options(net, sym_mode=pp_calc_mode)
     net_params["medium_temp_C"] = net_data.at[0, "TEMP"]
     net_params["medium_temp_K"] = net_data.at[0, "TEMP"] + 273.15
     net_params["calculation_results_valid"] = not bool(net_data.at[0, "CALCDIRTY"])

--- a/src/pandapipes/enums.py
+++ b/src/pandapipes/enums.py
@@ -1,0 +1,34 @@
+import enum
+
+class PhysDomain(str, enum.Enum):
+    """Physical domain for simulation components."""
+    HYD = "hydraulics"
+    HEAT = "heat_transfer"
+
+    def __str__(self):
+        """str representation of PhysDomain member.
+
+        Overridden to allow string operations on members
+
+        Example:
+        >> f"active_{PhysDomain.HEAT}"  # "active_heat_transfer"
+        """
+        return self.value
+
+class SimMode(str, enum.Enum):
+    """Modes for pipeflow simulation."""
+    HYD = "hydraulics"
+    HEAT = "heat"
+    SEQ = "sequential"
+    BIDIR = "bidirectional"
+    ALL = "ALL"
+
+    def __str__(self):
+        """str representation of SimMode member.
+
+        Overridden to allow string operations on members
+
+        Example:
+        >> f"used mode: {SimMode.HEAT}"  # "used mode: heat"
+        """
+        return self.value

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -247,9 +247,9 @@ def init_options(net, **kwargs):
                  same in each iteration) or "automatic", in which case **alpha** is adapted \
                  automatically with respect to the convergence behaviour.
 
-        - **mode** (str): "hydraulics" - Define the calculation mode: what shall be calculated - \
-                solely hydraulics ('hydraulics'), solely heat transfer('heat') or both combined sequentially \
-                ('sequential') or bidirectionally ('bidirectional').
+        - **sym_mode** (str): SimMode.HYD - Define the simulation mode: what shall be calculated - \
+                solely hydraulics (SimMode.HYD), solely heat transfer (SimMode.HEAT) or both combined sequentially \
+                (SimMode.SEQ) or bidirectionally (SimMode.BIDIR).
 
         - **only_update_hydraulic_matrix** (bool): False - If True, the system matrix is not \
                 created in every iteration, but only the data is updated according to a lookup that\
@@ -591,9 +591,8 @@ def check_connectivity(net, branch_pit, node_pit,
     :type branches_connected: np.array(bool)
     :param nodes_connected: Array of bool if nodes are connected or not
     :type nodes_connected: np.array(bool)
-    :param mode: two modes exist: "hydraulics" and "heat_transfer", representing the two modes of \
-        the pipeflow calculation.
-    :type mode: str
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain, default PhysDomain.HYD
     :return: (nodes_connected, branches_connected) - Lookups of np.arrays stating which of the
             internal nodes and branches are reachable from any of the hyd_slacks (np mask).
     :rtype: tuple(np.array)
@@ -609,6 +608,25 @@ def check_connectivity(net, branch_pit, node_pit,
 
 def perform_connectivity_search(net, node_pit, branch_pit, slack_nodes, active_node_lookup, active_branch_lookup,
                                 domain: PhysDomain = PhysDomain.HYD):
+    """
+    :param net: The pandapipesNet for which to perform the check
+    :type net: pandapipesNet
+    :param node_pit: Internal array with node entries
+    :type node_pit: np.array
+    :param branch_pit: Internal array with branch entries
+    :type branch_pit: np.array
+    :param slack_nodes:
+    :type slack_nodes:
+    :param active_node_lookup:
+    :type active_node_lookup:
+    :param active_branch_lookup:
+    :type active_branch_lookup:
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain, default PhysDomain.HYD
+    :return: (nodes_connected, branches_connected) - Lookups of np.arrays stating which of the
+            internal nodes and branches are reachable from any of the hyd_slacks (np mask).
+    :rtype: tuple(np.array)
+    """
     if domain == PhysDomain.HYD:
         connect = branch_pit[:, FLOW_RETURN_CONNECT].astype(bool)
         active_branch_lookup = active_branch_lookup & ~connect
@@ -626,6 +644,25 @@ def perform_connectivity_search(net, node_pit, branch_pit, slack_nodes, active_n
 
 
 def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, domain: PhysDomain):
+    """
+    :param net: The pandapipesNet for which to perform the check
+    :type net: pandapipesNet
+    :param branch_pit: Internal array with branch entries
+    :type branch_pit: np.array
+    :param node_pit: Internal array with node entries
+    :type node_pit: np.array
+    :param active_branch_lookup:
+    :type active_branch_lookup:
+    :param active_node_lookup:
+    :type active_node_lookup:
+    :param slack_nodes:
+    :type slack_nodes:
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain
+    :return: (nodes_connected, branches_connected) - Lookups of np.arrays stating which of the
+            internal nodes and branches are reachable from any of the hyd_slacks (np mask).
+    :rtype: tuple(np.array)
+    """
     len_nodes = len(node_pit)
     from_nodes = branch_pit[:, FROM_NODE].astype(np.int32)
     to_nodes = branch_pit[:, TO_NODE].astype(np.int32)
@@ -712,9 +749,8 @@ def reduce_pit(net, domain: PhysDomain = PhysDomain.HYD):
 
     :param net: The pandapipesNet for which the pit shall be reduced
     :type net: pandapipesNet
-    :param mode: the mode of the calculation (either "hydraulics" or "heat_transfer") for storing /\
-        retrieving correct lookups
-    :type mode: str, default "hydraulics"
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain, default PhysDomain.HYD
     :return: No output
     """
 

--- a/src/pandapipes/pf/pipeflow_setup.py
+++ b/src/pandapipes/pf/pipeflow_setup.py
@@ -20,6 +20,7 @@ from pandapipes.idx_branch import (
 from pandapipes.idx_node import NODE_TYPE, P, NODE_TYPE_T, node_cols, T, ACTIVE as ACTIVE_ND, \
     TABLE_IDX as TABLE_IDX_ND, ELEMENT_IDX as ELEMENT_IDX_ND, INFEED, GE
 from pandapipes.properties.fluids import get_fluid
+from pandapipes.enums import SimMode, PhysDomain
 
 try:
     import numba
@@ -41,7 +42,7 @@ logger = logging.getLogger(__name__)
 default_options = {"friction_model": "nikuradse", "tol_p": 1e-5, "tol_m": 1e-5,
                    "tol_T": 1e-3, "tol_res": 1e-3, "max_iter_hyd": 10, "max_iter_therm": 10,
                    "max_iter_bidirect": 10, "error_flag": False, "alpha": 1,
-                   "nonlinear_method": "constant", "mode": "hydraulics",
+                   "nonlinear_method": "constant", "sim_mode": SimMode.HYD,
                    "ambient_temperature": 293.15, "check_connectivity": True,
                    "max_iter_colebrook": 10, "only_update_hydraulic_matrix": False,
                    "reuse_internal_data": False, "use_numba": True,
@@ -333,13 +334,18 @@ def _iteration_check(opts):
 
 
 def _mode_check(opts):
-    if opts["mode"] == "all":
+    sim_mode = opts.get("mode", None)
+    # allow "mode" keyword in public api,
+    # but convert it to "sim_mode" for internal use
+    if sim_mode is not None:
+        opts["sim_mode"] = SimMode(opts.pop("mode"))
+    if opts["sim_mode"] == SimMode.ALL:
         logger.warning(
             "mode 'all' is deprecated and will be removed in a future release. "
             "Use 'sequential' or 'bidirectional' instead. "
             "For now 'all' is set equal to 'sequential'.",
         )
-        opts["mode"] = "sequential"
+        opts["sim_mode"] = SimMode.SEQ
 
 def create_internal_results(net):
     """
@@ -480,7 +486,6 @@ def create_lookups(net):
                        "node_length": node_from, "branch_length": branch_from,
                        "internal_nodes": internal_nodes, "internal_branches": internal_branches}
 
-
 def identify_active_nodes_branches(net, hydraulic=True):
     """
     Function that creates the connectivity lookup for nodes and branches. If the option \
@@ -511,14 +516,14 @@ def identify_active_nodes_branches(net, hydraulic=True):
         if get_net_option(net, "check_connectivity"):
             nodes_connected, branches_connected = check_connectivity(net, branch_pit, node_pit,
                                                                      branches_connected, nodes_connected,
-                                                                     mode="hydraulics")
+                                                                     domain=PhysDomain.HYD)
     else:
         nodes_connected = get_lookup(net, "node", "active_hydraulics")
         branches_connected = get_lookup(net, "branch", "active_hydraulics")
         if get_net_option(net, "check_connectivity"):
             nodes_connected, branches_connected = check_connectivity(net, branch_pit, node_pit,
                                                                      branches_connected, nodes_connected,
-                                                                     mode="heat_transfer")
+                                                                     domain=PhysDomain.HEAT)
         fn = branch_pit[:, FROM_NODE].astype(np.int32)
         tn = branch_pit[:, TO_NODE].astype(np.int32)
         branches_flow = branches_not_zero_flow(branch_pit)
@@ -531,14 +536,14 @@ def identify_active_nodes_branches(net, hydraulic=True):
             branches_connected = branches_flow & branches_connected
             nodes_connected = nodes_flow & nodes_connected
 
-    mode = "hydraulics" if hydraulic else "heat_transfer"
+    domain = PhysDomain.HYD if hydraulic else PhysDomain.HEAT
     if np.all(~nodes_connected):
-        mode = 'hydraulic' if hydraulic else 'heat transfer'
+        str_domain = 'hydraulic' if hydraulic else 'heat transfer'
         raise PipeflowNotConverged(" All nodes are set out of service. Probably they are not supplied."
                                    " Therefore, the %s pipeflow did not converge. "
-                                   " Have you forgotten to define a supply component or is it not properly connected?" % mode)
-    net["_lookups"]["node_active_" + mode] = nodes_connected
-    net["_lookups"]["branch_active_" + mode] = branches_connected
+                                   " Have you forgotten to define a supply component or is it not properly connected?" % str_domain)
+    net["_lookups"]["node_active_" + domain] = nodes_connected
+    net["_lookups"]["branch_active_" + domain] = branches_connected
 
 
 def branches_not_zero_flow(branch_pit):
@@ -556,7 +561,7 @@ def branches_not_zero_flow(branch_pit):
 
 def check_connectivity(net, branch_pit, node_pit,
                        branches_connected, nodes_connected,
-                       mode="hydraulics"):
+                       domain: PhysDomain = PhysDomain.HYD):
     """
     Perform a connectivity check which means that network nodes are identified that don't have any
     connection to an external grid component. Quick overview over the steps of this function:
@@ -593,22 +598,22 @@ def check_connectivity(net, branch_pit, node_pit,
             internal nodes and branches are reachable from any of the hyd_slacks (np mask).
     :rtype: tuple(np.array)
     """
-    if mode == "hydraulics":
+    if domain == PhysDomain.HYD:
         slacks = np.where((node_pit[:, NODE_TYPE] == P) & nodes_connected)[0]
     else:
         slacks = np.where(((node_pit[:, NODE_TYPE_T] == T) | (node_pit[:, NODE_TYPE_T] == GE)) & nodes_connected)[0]
 
     return perform_connectivity_search(net, node_pit, branch_pit, slacks,
-                                       nodes_connected, branches_connected, mode=mode)
+                                       nodes_connected, branches_connected, domain=domain)
 
 
 def perform_connectivity_search(net, node_pit, branch_pit, slack_nodes, active_node_lookup, active_branch_lookup,
-                                mode="hydraulics"):
-    if mode == 'hydraulics':
+                                domain: PhysDomain = PhysDomain.HYD):
+    if domain == PhysDomain.HYD:
         connect = branch_pit[:, FLOW_RETURN_CONNECT].astype(bool)
         active_branch_lookup = active_branch_lookup & ~connect
         nodes_connected, branches_connected = (
-            _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, mode))
+            _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, domain))
         from_nodes = branch_pit[:, FROM_NODE].astype(np.int32)
         to_nodes = branch_pit[:, TO_NODE].astype(np.int32)
         branch_active = branch_pit[:, ACTIVE].astype(bool)
@@ -616,11 +621,11 @@ def perform_connectivity_search(net, node_pit, branch_pit, slack_nodes, active_n
         branches_connected[connect & active] = True
     else:
         nodes_connected, branches_connected = (
-            _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, mode))
+            _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, domain))
     return nodes_connected, branches_connected
 
 
-def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, mode):
+def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_lookup, slack_nodes, domain: PhysDomain):
     len_nodes = len(node_pit)
     from_nodes = branch_pit[:, FROM_NODE].astype(np.int32)
     to_nodes = branch_pit[:, TO_NODE].astype(np.int32)
@@ -648,7 +653,7 @@ def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_l
     if not np.all(nodes_connected[active_from_nodes] == nodes_connected[active_to_nodes]):
         raise ValueError(
             "An error occured in the %s connectivity check. Please contact the pandapipes "
-            "development team!" % mode)
+            "development team!" % domain)
     branches_connected = active_branch_lookup & nodes_connected[from_nodes]
 
     oos_nodes = np.where(~nodes_connected & active_node_lookup)[0]
@@ -658,7 +663,7 @@ def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_l
         msg = "\n".join("In table %s: %s" % (tbl, nds) for tbl, nds in
                         get_table_index_list(net, node_pit, oos_nodes))
         logger.info("Setting the following nodes out of service for %s calculation in connectivity"
-                    " check:\n%s" % (mode, msg))
+                    " check:\n%s" % (domain, msg))
 
     if len(is_nodes) > 0:
         node_type_message = "\n".join("In table %s: %s" % (tbl, nds) for tbl, nds in
@@ -667,10 +672,10 @@ def _connectivity(net, branch_pit, node_pit, active_branch_lookup, active_node_l
             raise UserWarning(
                 "The following nodes are connected to in_service branches in the %s calculation "
                 "although being out of service, which leads to an inconsistency in the connectivity"
-                " check!\n%s" % (mode, node_type_message))
+                " check!\n%s" % (domain, node_type_message))
         logger.info("Setting the following nodes back in service for %s calculation in connectivity"
                     " check as they are connected to in_service branches:\n%s"
-                    % (mode, node_type_message))
+                    % (domain, node_type_message))
 
     return nodes_connected, branches_connected
 
@@ -698,7 +703,7 @@ def get_table_index_list(net, pit_array, pit_indices, pit_type="node"):
             for tbl in tables]
 
 
-def reduce_pit(net, mode="hydraulics"):
+def reduce_pit(net, domain: PhysDomain = PhysDomain.HYD):
     """
     Create an internal ("active") pit with all nodes and branches that are actually in_service. This
     is also done for different lookups (e.g. the from_to indices for this pit and the node index
@@ -719,38 +724,38 @@ def reduce_pit(net, mode="hydraulics"):
     active_pit = dict()
     els = dict()
     reduced_node_lookup = None
-    nodes_connected = get_lookup(net, "node", "active_" + mode)
-    branches_connected = get_lookup(net, "branch", "active_" + mode)
+    nodes_connected = get_lookup(net, "node", "active_" + domain)
+    branches_connected = get_lookup(net, "branch", "active_" + domain)
     if np.all(nodes_connected):
-        net["_lookups"]["node_from_to_active_" + mode] = copy.deepcopy(
+        net["_lookups"]["node_from_to_active_" + domain] = copy.deepcopy(
             get_lookup(net, "node", "from_to"))
-        net["_lookups"]["node_index_active_" + mode] = copy.deepcopy(
+        net["_lookups"]["node_index_active_" + domain] = copy.deepcopy(
             get_lookup(net, "node", "index"))
         active_pit["node"] = np.copy(node_pit)
     else:
         active_pit["node"] = np.copy(node_pit[nodes_connected, :])
         reduced_node_lookup = np.cumsum(nodes_connected) - 1
         node_idx_lookup = get_lookup(net, "node", "index")
-        net["_lookups"]["node_index_active_" + mode] = {
+        net["_lookups"]["node_index_active_" + domain] = {
             tbl: reduced_node_lookup[idx_lookup[idx_lookup != -1]]
             for tbl, idx_lookup in node_idx_lookup.items()}
         els["node"] = nodes_connected
     if np.all(branches_connected):
-        net["_lookups"]["branch_from_to_active_" + mode] = copy.deepcopy(
+        net["_lookups"]["branch_from_to_active_" + domain] = copy.deepcopy(
             get_lookup(net, "branch", "from_to"))
         active_pit["branch"] = np.copy(branch_pit)
-        net["_lookups"]["branch_index_active_" + mode] = copy.deepcopy(
+        net["_lookups"]["branch_index_active_" + domain] = copy.deepcopy(
             get_lookup(net, "branch", "index"))
     else:
         active_pit["branch"] = np.copy(branch_pit[branches_connected, :])
         branch_idx_lookup = get_lookup(net, "branch", "index")
         if len(branch_idx_lookup):
             reduced_branch_lookup = np.cumsum(branches_connected) - 1
-            net["_lookups"]["branch_index_active_" + mode] = {
+            net["_lookups"]["branch_index_active_" + domain] = {
                 tbl: reduced_branch_lookup[idx_lookup[idx_lookup != -1]]
                 for tbl, idx_lookup in branch_idx_lookup.items()}
         else:
-            net["_lookups"]["branch_index_active_" + mode] = dict()
+            net["_lookups"]["branch_index_active_" + domain] = dict()
         els["branch"] = branches_connected
     if reduced_node_lookup is not None:
         active_pit["branch"][:, FROM_NODE] = reduced_node_lookup[
@@ -768,7 +773,7 @@ def reduce_pit(net, mode="hydraulics"):
         for table, (_, _, len_new) in sorted(aux_lookup.items(), key=lambda x: x[1][0]):
             from_to_active_lookup[table] = (count, count + len_new)
             count += len_new
-        net["_lookups"]["%s_from_to_active_%s" % (el, mode)] = from_to_active_lookup
+        net["_lookups"]["%s_from_to_active_%s" % (el, domain)] = from_to_active_lookup
 
 
 def check_infeed_number(node_pit):

--- a/src/pandapipes/pf/result_extraction.py
+++ b/src/pandapipes/pf/result_extraction.py
@@ -23,8 +23,8 @@ def extract_all_results(net, sim_mode: SimMode):
 
     :param net: pandapipes net for which to extract results into net.res_xy
     :type net: pandapipesNet
-    :param calculation_mode: mode of the simulation (e.g. "hydraulics" or "heat" or "sequential" or "bidirectional")
-    :type calculation_mode: str
+    :param sim_mode: Simulation mode determining which results to extract.
+    :type sim_mode: SimMode
     :return: No output
 
     """
@@ -164,6 +164,38 @@ def extract_branch_results_with_internals(net, branch_results, table_name,
                                           res_nodes_to_hydraulics, res_nodes_to_heat,
                                           res_mean_hydraulics, res_branch_ht, res_mean_heat, internal_node_name,
                                           sim_mode: SimMode):
+    """
+    Extract the results from the branch result array derived from the pit to the result table of the
+    net (only for branch components with internal nodes). Here, we need to consider which results
+    exist for hydraulic calculation and for heat transfer calculation (wrt. connectivity).
+
+    :param net: The pandapipes net that the internal structure belongs to
+    :type net: pandapipesNet
+    :param branch_results: Important branch results from the internal pit structure
+    :type branch_results: dict[np.ndarray]
+    :param table_name: The name of the table that the results should be written to
+    :type table_name: str
+    :param res_nodes_from_hydraulics:
+    :type res_nodes_from_hydraulics:
+    :param res_nodes_from_heat:
+    :type res_nodes_from_heat:
+    :param res_nodes_to_hydraulics:
+    :type res_nodes_to_hydraulics:
+    :param res_nodes_to_heat:
+    :type res_nodes_to_heat:
+    :param res_mean_hydraulics:
+    :type res_mean_hydraulics:
+    :param res_branch_ht:
+    :type res_branch_ht:
+    :param res_mean_heat:
+    :type res_mean_heat:
+    :param internal_node_name:
+    :type internal_node_name:
+    :param sim_mode: Simulation mode determining which results to extract.
+    :type sim_mode: SimMode
+    :return: No output
+    :rtype: None
+    """
     # the result table to write results to
     res_table = net["res_" + table_name]
 
@@ -250,9 +282,8 @@ def extract_branch_results_without_internals(net, branch_results, required_resul
     :type required_results_heat: list[tuple]
     :param table_name: The name of the table that the results should be written to
     :type table_name: str
-    :param simulation_mode: simulation mode (e.g. "hydraulics", "heat", "sequential", "bidirectional"); defines whether results from \
-        hydraulic or temperature calculation are transferred
-    :type simulation_mode: str
+    :param sim_mode: Simulation mode determining which results to extract.
+    :type sim_mode: SimMode
     :return: No output
     :rtype: None
     """
@@ -287,8 +318,8 @@ def extract_results_active_pit(net, domain: PhysDomain = PhysDomain.HYD):
 
     :param net: The pandapipes net that the internal structure belongs to
     :type net: pandapipesNet
-    :param mode: defines whether results from hydraulic or temperature calculation are transferred
-    :type mode: str, default "hydraulics"
+    :param domain: Physical domain for the calculation (hydraulics or heat_transfer)
+    :type domain: PhysDomain, default PhysDomain.HYD
     :return: No output
 
     """

--- a/src/pandapipes/pipeflow.py
+++ b/src/pandapipes/pipeflow.py
@@ -113,6 +113,24 @@ def use_given_hydraulic_results(net, sol_vec):
 
 
 def newton_raphson(net, funct, sim_mode: SimMode, solver_vars, tols, pit_names, iter_name):
+    """
+    :param net: A pandapipes net
+    :type net: pandapipesNet
+    :param funct:
+    :type funct:
+    :param sim_mode: Simulation mode for the pipeflow
+    :type sim_mode: SimMode
+    :param solver_vars:
+    :type solver_vars:
+    :param tols:
+    :type tols:
+    :param pit_names:
+    :type pit_names:
+    :param iter_name:
+    :type iter_name:
+    :return: No output.
+    :rtype: None
+    """
     max_iter, nonlinear_method, tol_res = get_net_options(
         net, iter_name, "nonlinear_method", "tol_res"
     )

--- a/src/pandapipes/pipeflow.py
+++ b/src/pandapipes/pipeflow.py
@@ -18,6 +18,7 @@ from pandapipes.pf.pipeflow_setup import (
     check_infeed_number, PipeflowNotConverged
 )
 from pandapipes.pf.result_extraction import extract_all_results, extract_results_active_pit
+from pandapipes.enums import PhysDomain, SimMode
 
 try:
     import pandaplan.core.pplog as logging
@@ -63,7 +64,6 @@ def pipeflow(net, sol_vec=None, **kwargs):
 
     # Init physical constants and options
     init_options(net, **kwargs)
-    calculation_mode = get_net_option(net, "mode")
 
     # init result tables
     net.converged = False
@@ -72,10 +72,10 @@ def pipeflow(net, sol_vec=None, **kwargs):
     create_lookups(net)
     initialize_pit(net)
 
-    calculation_mode = get_net_option(net, "mode")
-    calculate_hydraulics = calculation_mode in ["hydraulics", 'sequential']
-    calculate_heat = calculation_mode in ["heat", 'sequential']
-    calculate_bidrect = calculation_mode == "bidirectional"
+    sim_mode = SimMode(get_net_option(net, "sim_mode"))
+    calculate_hydraulics = sim_mode in {SimMode.HYD, SimMode.SEQ}
+    calculate_heat = sim_mode in {SimMode.HEAT, SimMode.SEQ}
+    calculate_bidirect = sim_mode == SimMode.BIDIR
 
 
     # TODO: This is not necessary in every time step, but we need the result! The result of the
@@ -84,12 +84,12 @@ def pipeflow(net, sol_vec=None, **kwargs):
     # determine the active node/branch heat transfer lookup
     identify_active_nodes_branches(net)
 
-    if calculation_mode == 'heat':
+    if sim_mode == SimMode.HEAT:
         use_given_hydraulic_results(net, sol_vec)
 
-    if not (calculate_hydraulics | calculate_heat | calculate_bidrect):
+    if not (calculate_hydraulics | calculate_heat | calculate_bidirect):
         raise UserWarning("No proper calculation mode chosen.")
-    elif calculate_bidrect:
+    elif calculate_bidirect:
         bidirectional(net)
     else:
         if calculate_hydraulics:
@@ -97,7 +97,7 @@ def pipeflow(net, sol_vec=None, **kwargs):
         if calculate_heat:
             heat_transfer(net)
 
-    extract_all_results(net, calculation_mode)
+    extract_all_results(net, sim_mode)
 
 
 def use_given_hydraulic_results(net, sol_vec):
@@ -112,7 +112,7 @@ def use_given_hydraulic_results(net, sol_vec):
         branch_pit[:, MDOTINIT] = sol_vec[len(node_pit):]
 
 
-def newton_raphson(net, funct, mode, solver_vars, tols, pit_names, iter_name):
+def newton_raphson(net, funct, sim_mode: SimMode, solver_vars, tols, pit_names, iter_name):
     max_iter, nonlinear_method, tol_res = get_net_options(
         net, iter_name, "nonlinear_method", "tol_res"
     )
@@ -156,10 +156,10 @@ def newton_raphson(net, funct, mode, solver_vars, tols, pit_names, iter_name):
         niter += 1
     write_internal_results(net, **errors)
     kwargs = dict()
-    kwargs['residual_norm_%s' % mode] = residual_norm
-    kwargs['iterations_%s' % mode] = niter
+    kwargs['residual_norm_%s' % sim_mode] = residual_norm
+    kwargs['iterations_%s' % sim_mode] = niter
     write_internal_results(net, **kwargs)
-    log_final_results(net, mode, niter, residual_norm, solver_vars, tols)
+    log_final_results(net, sim_mode, niter, residual_norm, solver_vars, tols)
 
 
 def bidirectional(net):
@@ -169,7 +169,7 @@ def bidirectional(net):
     solver_vars = ['mdot', 'p', 'TOUT', 'T']
     tol_m, tol_p, tol_temp = get_net_options(net, 'tol_m', 'tol_p', 'tol_T')
     newton_raphson(
-        net, solve_bidirectional, 'bidirectional', solver_vars, [tol_m, tol_p, tol_temp, tol_temp],
+        net, solve_bidirectional, SimMode.BIDIR, solver_vars, [tol_m, tol_p, tol_temp, tol_temp],
         ['branch', 'node', 'branch', 'node'], 'max_iter_bidirect'
     )
     if net.converged:
@@ -184,12 +184,12 @@ def hydraulics(net):
     # Start of nonlinear loop
     # ---------------------------------------------------------------------------------------------
     net.converged = False
-    reduce_pit(net, mode="hydraulics")
+    reduce_pit(net, domain=PhysDomain.HYD)
     if not get_net_option(net, "reuse_internal_data") or "_internal_data" not in net:
         net["_internal_data"] = dict()
     solver_vars = ['mdot', 'p', 'mdotslack']
     tol_p, tol_m, tol_msl = get_net_options(net, 'tol_m', 'tol_p', 'tol_m')
-    newton_raphson(net, solve_hydraulics, 'hydraulics', solver_vars, [tol_m, tol_p, tol_msl],
+    newton_raphson(net, solve_hydraulics, SimMode.HYD, solver_vars, [tol_m, tol_p, tol_msl],
                    ['branch', 'node', 'node'], 'max_iter_hyd')
     if net.converged:
         set_user_pf_options(net, hyd_flag=True)
@@ -200,7 +200,7 @@ def hydraulics(net):
     if not net.converged:
         msg = "The hydraulic calculation did not converge to a solution."
         raise PipeflowNotConverged(msg)
-    extract_results_active_pit(net, mode="hydraulics")
+    extract_results_active_pit(net, domain=PhysDomain.HYD)
 
 
 def heat_transfer(net):
@@ -208,28 +208,28 @@ def heat_transfer(net):
     # ---------------------------------------------------------------------------------------------
     net.converged = False
     identify_active_nodes_branches(net, False)
-    reduce_pit(net, mode="heat_transfer")
+    reduce_pit(net, domain=PhysDomain.HEAT)
     if net.fluid.is_gas:
         logger.info("Caution! Temperature calculation does currently not affect hydraulic "
                     "properties!")
     solver_vars = ['Tout', 'T']
     tol_temp = next(get_net_options(net, 'tol_T'))
-    newton_raphson(net, solve_temperature, 'heat', solver_vars, [tol_temp, tol_temp], ['branch', 'node'],
+    newton_raphson(net, solve_temperature, SimMode.HEAT, solver_vars, [tol_temp, tol_temp], ['branch', 'node'],
                    'max_iter_therm')
     if not net.converged:
         msg = "The heat transfer calculation did not converge to a solution."
         raise PipeflowNotConverged(msg)
-    extract_results_active_pit(net, mode="heat_transfer")
+    extract_results_active_pit(net, domain=PhysDomain.HEAT)
 
 
 def solve_bidirectional(net):
-    reduce_pit(net, mode="hydraulics")
+    reduce_pit(net, domain=PhysDomain.HYD)
     res_hyd, residual_hyd = solve_hydraulics(net)
-    extract_results_active_pit(net, mode="hydraulics")
+    extract_results_active_pit(net, domain=PhysDomain.HYD)
     identify_active_nodes_branches(net, False)
-    reduce_pit(net, mode="heat_transfer")
+    reduce_pit(net, domain=PhysDomain.HEAT)
     res_heat, residual_heat = solve_temperature(net)
-    extract_results_active_pit(net, mode="heat_transfer")
+    extract_results_active_pit(net, domain=PhysDomain.HEAT)
     residual = np.concatenate([residual_hyd, residual_heat])
     res = res_hyd + res_heat
     return res, residual


### PR DESCRIPTION
### Summary
This PR introduces an `Enum` class `SimMode` to replace raw string representations of simulation modes, providing better type safety and developer experience. Additionally, it identifies and implements a new `PhysDomain` concept to distinguish between simulation modes and physical domains.
### Key Changes
1. **Added `SimMode` Enum**:
    ```python
    class SimMode(Enum):
        HYD = "hydraulics"       # Hydraulic simulation
        HEAT = "heat"             # Thermal simulation
        SEQ = "sequential"        # Sequential coupled simulation
        BIDIR = "bidirectional"   # Bidirectional coupled simulation
    ```
    - Replaces raw strings throughout the codebase
    - Provides autocompletion and prevents typos
    - Centralizes mode definitions
2. **Added `PhysDomain` Enum**:
    ```python
    class PhysDomain(Enum):
        HYD = "hydraulics"        # Hydraulic results domain
        HEAT = "heat_transfer"    # Thermal results domain
    ```
    - Separates simulation method from physical domain
    - Clarifies previously ambiguous "mode" concept
3. **API Improvements**:
    - Renamed internal `mode` parameters to `sim_mode` for clarity
    - **Backward compatibility maintained**: Users can still call `pipeflow(net, mode="hydraulics")`
    - Updated function documentation throughout affected modules
4. **Documentation**:
    - Updated docstrings for all modified functions
    - Added explanations for new enums in relevant modules
### Why Enums?
- **IDE Support**: Auto-completion and discoverability  
- **Safety**: Eliminates string typos in mode specifications  
- **Maintainability**: All modes defined in single location  
- **Clarity**: Explicit separation of simulation method vs physical domain  
### Pending Items (Future PRs)
- Updating test cases to use new enums (current tests unchanged to limit scope)

## Feedback Requested
### Naming Concerns
I'm uncertain if these names are optimal. Please suggest alternatives:
- `SimMode` → `CalcMode`?  
- `PhysDomain` → `ResultMode`?  
- Is `PhysDomain` concept actually needed?  

The renaming is trivial, so please don't feel burdened by suggesting your preferences!
### Import Concert
Currently enums are imported as:
```python
from pandapipes.enums import SimMode
```
But would this be more user-friendly?
```python
from pandapipes import SimMode  # Direct top-level import
```