### PR TITLE
Feature: implementation of an exponential heat loss function in pipes

### DIFF
--- a/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
+++ b/src/pandapipes/component_models/abstract_models/branch_w_internals_models.py
@@ -6,7 +6,14 @@ import numpy as np
 
 from pandapipes.component_models.abstract_models.branch_models import BranchComponent
 from pandapipes.component_models.component_toolbox import set_entry_check_repeat, get_internal_lookup_structure
-from pandapipes.idx_branch import ACTIVE, ELEMENT_IDX, D, LOSS_COEFFICIENT as LC, AREA
+from pandapipes.idx_branch import (
+    ACTIVE,
+    ELEMENT_IDX,
+    D,
+    LOSS_COEFFICIENT as LC,
+    AREA,
+    QEXT,
+)
 from pandapipes.idx_node import L, node_cols
 from pandapipes.pf.pipeflow_setup import add_table_lookup, get_lookup, get_table_number, get_net_option
 
@@ -190,6 +197,7 @@ class BranchWInternalsComponent(BranchComponent):
                 has_internals)
 
             branch_w_internals_pit[:, AREA] = branch_w_internals_pit[:, D] ** 2 * np.pi / 4
+            branch_w_internals_pit[:, QEXT] = 0.0
         return branch_w_internals_pit, node_pit
 
     @classmethod

--- a/src/pandapipes/component_models/pipe_component.py
+++ b/src/pandapipes/component_models/pipe_component.py
@@ -144,7 +144,8 @@ class Pipe(BranchWInternalsComponent):
                 internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, K, net[tbl].k_mm.values / 1000, internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, ALPHA, net[tbl].u_w_per_m2k.values, internal_pipe_number, has_internals)
-            set_entry_check_repeat(pipe_pit, QEXT, net[tbl].qext_w.values, internal_pipe_number, has_internals)
+            set_entry_check_repeat(pipe_pit, QEXT, net[tbl].qext_w.values / internal_pipe_number,
+                                   internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, TEXT, net[tbl].text_k.values, internal_pipe_number, has_internals)
             nan_mask = np.isnan(pipe_pit[:, TEXT])
             pipe_pit[nan_mask, TEXT] = get_net_option(net, 'ambient_temperature')

--- a/src/pandapipes/component_models/pipe_component.py
+++ b/src/pandapipes/component_models/pipe_component.py
@@ -10,7 +10,7 @@ from pandapipes.component_models.abstract_models import BranchWInternalsComponen
 from pandapipes.component_models.component_toolbox import set_entry_check_repeat, vinterp, p_correction_height_air
 from pandapipes.component_models.junction_component import Junction
 from pandapipes.constants import NORMAL_TEMPERATURE, NORMAL_PRESSURE
-from pandapipes.idx_branch import FROM_NODE, TO_NODE, LENGTH, D, AREA, K, MDOTINIT, ALPHA, QEXT, TEXT, TOUTINIT, \
+from pandapipes.idx_branch import FROM_NODE, TO_NODE, LENGTH, D, AREA, K, MDOTINIT, ALPHA, TEXT, TOUTINIT, \
     T_OUT_OLD
 from pandapipes.idx_node import (TINIT as TINIT_NODE, HEIGHT, PINIT, PAMB, ACTIVE as ACTIVE_ND, TINIT_OLD, )
 from pandapipes.pf.pipeflow_setup import get_fluid, get_lookup, get_net_option
@@ -144,8 +144,6 @@ class Pipe(BranchWInternalsComponent):
                 internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, K, net[tbl].k_mm.values / 1000, internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, ALPHA, net[tbl].u_w_per_m2k.values, internal_pipe_number, has_internals)
-            set_entry_check_repeat(pipe_pit, QEXT, net[tbl].qext_w.values / internal_pipe_number,
-                                   internal_pipe_number, has_internals)
             set_entry_check_repeat(pipe_pit, TEXT, net[tbl].text_k.values, internal_pipe_number, has_internals)
             nan_mask = np.isnan(pipe_pit[:, TEXT])
             pipe_pit[nan_mask, TEXT] = get_net_option(net, 'ambient_temperature')

--- a/src/pandapipes/create.py
+++ b/src/pandapipes/create.py
@@ -1396,10 +1396,9 @@ def create_pipes(net, from_junctions, to_junctions, std_type, length_km, k_mm=0.
 
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
                "std_type": std_type, "length_km": length_km,
-               "diameter_m": pipe_parameters["inner_diameter_mm"] / 1000, "k_mm": pipe_parameters['k_mm'],
+               "diameter_m": pipe_parameters["inner_diameter_mm"] / 1000, "k_mm": k_mm,
                "loss_coefficient": loss_coefficient, "u_w_per_m2k": pipe_parameters['u_w_per_m2k'],
-               "sections": sections, "in_service": in_service, "type": type, "qext_w": qext_w,
-               "text_k": text_k}
+               "sections": sections, "in_service": in_service, "type": type, "text_k": text_k}
     _set_multiple_entries(net, "pipe", index, **entries, **kwargs)
 
     if geodata is not None:
@@ -1471,10 +1470,13 @@ def create_pipes_from_parameters(net, from_junctions, to_junctions, length_km, d
     _check_branches(net, from_junctions, to_junctions, "pipe")
 
     if 'alpha_w_per_m2k' in kwargs:
-        if u_w_per_m2k == 0.:
+        warnings.warn(
+            "The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k."
+            "It will be removed in future.",
+            DeprecationWarning,
+        )
+        if not isinstance(u_w_per_m2k, Iterable) and u_w_per_m2k == 0.:
             u_w_per_m2k = kwargs['alpha_w_per_m2k']
-            warnings.warn("The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k."
-                          "It will be removed in future.", DeprecationWarning)
         del kwargs["alpha_w_per_m2k"]
 
     if "qext_w" in kwargs:
@@ -1486,8 +1488,7 @@ def create_pipes_from_parameters(net, from_junctions, to_junctions, length_km, d
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
                "std_type": None, "length_km": length_km, "diameter_m": diameter_m, "k_mm": k_mm,
                "loss_coefficient": loss_coefficient, "u_w_per_m2k": u_w_per_m2k,
-               "sections": sections, "in_service": in_service, "type": type, "qext_w": qext_w,
-               "text_k": text_k}
+               "sections": sections, "in_service": in_service, "type": type, "text_k": text_k}
 
     if 'std_type' in kwargs:
         raise UserWarning('you have defined a std_type, however, using this function you can only '

--- a/src/pandapipes/create.py
+++ b/src/pandapipes/create.py
@@ -521,9 +521,6 @@ def create_pipe_from_parameters(net, from_junction, to_junction, length_km, diam
                 "The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k." "It will be removed in future.",
                 DeprecationWarning)
             del kwargs['alpha_w_per_m2k']
-        else:
-            raise UserWarning(r"u_w_per_m2k and alpha_w_per_m2k have been both defined by you causing ambiguity. "
-                              r"Please make sure to define only one!")
 
     if "qext_w" in kwargs:
         warnings.warn("Due to the consideration of the ambient temperature, qext_w has " 
@@ -535,7 +532,7 @@ def create_pipe_from_parameters(net, from_junction, to_junction, length_km, diam
          "std_type": None, "length_km": length_km, "diameter_m": diameter_m, "k_mm": k_mm,
          "loss_coefficient": loss_coefficient, "u_w_per_m2k": u_w_per_m2k,
          "sections": sections, "in_service": bool(in_service),
-         "type": type, "qext_w": qext_w, "text_k": text_k}
+         "type": type, "text_k": text_k}
 
     if 'std_type' in kwargs:
         raise UserWarning('you have defined a std_type, however, using this function you can only '
@@ -1399,8 +1396,8 @@ def create_pipes(net, from_junctions, to_junctions, std_type, length_km, k_mm=0.
 
     entries = {"name": name, "from_junction": from_junctions, "to_junction": to_junctions,
                "std_type": std_type, "length_km": length_km,
-               "diameter_m": pipe_parameters["inner_diameter_mm"] / 1000, "k_mm": k_mm,
-               "loss_coefficient": loss_coefficient, "u_w_per_m2k": u_w_per_m2k,
+               "diameter_m": pipe_parameters["inner_diameter_mm"] / 1000, "k_mm": pipe_parameters['k_mm'],
+               "loss_coefficient": loss_coefficient, "u_w_per_m2k": pipe_parameters['u_w_per_m2k'],
                "sections": sections, "in_service": in_service, "type": type, "qext_w": qext_w,
                "text_k": text_k}
     _set_multiple_entries(net, "pipe", index, **entries, **kwargs)
@@ -1478,9 +1475,6 @@ def create_pipes_from_parameters(net, from_junctions, to_junctions, length_km, d
             u_w_per_m2k = kwargs['alpha_w_per_m2k']
             warnings.warn("The parameter alpha_w_per_m2k has been renamed to u_w_per_m2k."
                           "It will be removed in future.", DeprecationWarning)
-        else:
-            raise UserWarning(r"u_w_per_m2k and alpha_w_per_m2k have been both defined by you causing ambiguity. "
-                              r"Please make sure to define only one!")
         del kwargs["alpha_w_per_m2k"]
 
     if "qext_w" in kwargs:

--- a/src/pandapipes/pf/derivative_calculation.py
+++ b/src/pandapipes/pf/derivative_calculation.py
@@ -217,7 +217,7 @@ def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
 
     else:
         zero_length_mask = np.isclose(branch_pit[:, LENGTH], 0, rtol=1e-6, atol=1e-10)
-        if np.any(zero_length_mask & np.abs(branch_pit[:, QEXT]) > 1e-12):
+        if np.any(zero_length_mask & (np.abs(branch_pit[:, QEXT]) > 1e-12)):
             logger.warning(
                 "A branch with zero length has a non zero external heat load. This might lead to "
                 "errors in the calculation, as the overlap of temperature reduction from heat "

--- a/src/pandapipes/pf/derivative_calculation.py
+++ b/src/pandapipes/pf/derivative_calculation.py
@@ -104,8 +104,10 @@ def calculate_derivatives_hydraulic(net, branch_pit, node_pit, options):
 def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
     fluid = get_fluid(net)
     cp = get_branch_cp(fluid, node_pit, branch_pit)
-    m_init_i = np.abs(branch_pit[:, MDOTINIT])
-    m_init_i1 = np.abs(branch_pit[:, MDOTINIT])
+    # this is not required currently, but useful when implementing leakages
+    # m_init_i = np.abs(branch_pit[:, MDOTINIT])
+    # m_init_i1 = np.abs(branch_pit[:, MDOTINIT])
+    mdot = np.abs(branch_pit[:, MDOTINIT])
     from_nodes = get_from_nodes_corrected(branch_pit)
     to_nodes = get_to_nodes_corrected(branch_pit)
     t_init_i = node_pit[from_nodes, TINIT_NODE]
@@ -125,10 +127,10 @@ def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
     node_pit[:, JAC_DERIV_DT_LOAD] = - node_pit[:, LOAD] * cp_n
     node_pit[:, JAC_DERIV_DT_SLACK] = - node_pit[:, MDOTSLACKINIT] * cp_n
 
-    branch_pit[:, JAC_DERIV_DT_NODE] = - m_init_i * cp_i
-    branch_pit[:, JAC_DERIV_DTOUT_NODE] = m_init_i1 * cp_i1
-    branch_pit[:, LOAD_VEC_NODES_FROM_T] = m_init_i1 * t_init_i * cp_i
-    branch_pit[:, LOAD_VEC_NODES_TO_T] = m_init_i1 * t_init_i1 * cp_i1
+    branch_pit[:, JAC_DERIV_DT_NODE] = - mdot * cp_i
+    branch_pit[:, JAC_DERIV_DTOUT_NODE] = mdot * cp_i1
+    branch_pit[:, LOAD_VEC_NODES_FROM_T] = mdot * t_init_i * cp_i
+    branch_pit[:, LOAD_VEC_NODES_TO_T] = mdot * t_init_i1 * cp_i1
 
     if get_net_option(net, "transient"):
         rho = get_branch_real_density(fluid, node_pit, branch_pit)
@@ -138,12 +140,12 @@ def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
 
         branch_pit[:, LOAD_VEC_BRANCHES_T] = (
                 rho * area * cp * (t_init_i1 - tvor) * (1 / delta_t) * length
-                + cp * m_init_i * (-t_init_i + t_init_i1 - tl)
+                + cp * mdot * (-t_init_i + t_init_i1 - tl)
                 - alpha * (t_amb - t_init_i1) * length + qext
         )
 
-        branch_pit[:, JAC_DERIV_DT] = - cp * m_init_i
-        branch_pit[:, JAC_DERIV_DTOUT] = rho * area * cp / delta_t * length + cp * m_init_i + alpha
+        branch_pit[:, JAC_DERIV_DT] = - cp * mdot
+        branch_pit[:, JAC_DERIV_DTOUT] = rho * area * cp / delta_t * length + cp * mdot + alpha
 
         branches_active_ht = get_lookup(net, "branch", "active_heat_transfer")
         branches_zero_fl = get_lookup(net, "branch", "zero_flow")[branches_active_ht]
@@ -210,13 +212,13 @@ def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
             infeed_node = np.setdiff1d(from_nodes_not_zero, to_nodes_not_zero)
 
     else:
-        t_m = (t_init_i1 + t_init_i) / 2
-        m_m = (m_init_i + m_init_i1) / 2
 
-        branch_pit[:, JAC_DERIV_DT] = - cp * m_m + alpha / 2 * length
-        branch_pit[:, JAC_DERIV_DTOUT] = cp * m_m + alpha / 2 * length
-        branch_pit[:, LOAD_VEC_BRANCHES_T] = cp * m_m * (-t_init_i + t_init_i1 - tl) - alpha * (
-                    t_amb - t_m) * length + qext
+        branch_pit[:, LOAD_VEC_BRANCHES_T] = (
+                t_amb + (t_init_i - t_amb) * np.exp(- alpha * length / (cp * mdot))
+                - t_init_i1 + tl - qext / (cp * mdot)
+        )
+        branch_pit[:, JAC_DERIV_DT] = np.exp(- alpha * length / (cp * mdot))
+        branch_pit[:, JAC_DERIV_DTOUT] = -1
 
     if infeed_node is None:
         infeed_node = np.setdiff1d(from_nodes, to_nodes)
@@ -225,9 +227,9 @@ def calculate_derivatives_thermal(net, branch_pit, node_pit, _):
 
     # This approach can be used if you consider the effect of sources with given temperature (checkout issue #656)
 
-    # branch_pit[:, LOAD_VEC_NODES_FROM_T] = m_init_i * t_init_i * cp_i
+    # branch_pit[:, LOAD_VEC_NODES_FROM_T] = mdot * t_init_i * cp_i
     # --> cp_i is calculated by fluid.get_heat_capacity(t_init_i)
-    # branch_pit[:, LOAD_VEC_NODES_TO_T] = m_init_i1 * t_init_i1 * cp_i1
+    # branch_pit[:, LOAD_VEC_NODES_TO_T] = mdot * t_init_i1 * cp_i1
     # --> still missing is the derivative of loads
     # t_init = node_pit[:, TINIT_NODE]
     # cp_n = fluid.get_heat_capacity(t_init)

--- a/src/pandapipes/test/api/test_components/test_ext_grid.py
+++ b/src/pandapipes/test/api/test_components/test_ext_grid.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2020-2025 by Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel, and University of Kassel. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
-
+import copy
 import os
 
 import numpy as np
@@ -87,14 +87,16 @@ def test_t_type_single_pipe(use_numba):
 
     j0 = pandapipes.create_junction(net, pn_bar=5, tfluid_k=283)
     j1 = pandapipes.create_junction(net, pn_bar=5, tfluid_k=283)
-    pandapipes.create_ext_grid(net, j0, 5, 645, type="pt")
     pandapipes.create_sink(net, j1, 1)
     pandapipes.create_pipe_from_parameters(net, j0, j1, 6, diameter_m=d, k_mm=.1, sections=1,
                                            u_w_per_m2k=5)
 
     pandapipes.create_fluid_from_lib(net, "water", overwrite=True)
+    net2 = copy.deepcopy(net)
+    pandapipes.create_ext_grid(net, j0, 5, 645, type="pt")
+
     max_iter_hyd = 3 if use_numba else 3
-    max_iter_therm = 6 if use_numba else 6
+    max_iter_therm = 4 if use_numba else 4
     pandapipes.pipeflow(net, stop_condition="tol", max_iter_hyd=max_iter_hyd,
                         max_iter_therm=max_iter_therm, friction_model="nikuradse",
                         transient=False, nonlinear_method="automatic", tol_p=1e-4,
@@ -102,20 +104,10 @@ def test_t_type_single_pipe(use_numba):
 
     temp = net.res_junction.t_k.values
 
-    net2 = pandapipes.create_empty_network("net")
-    d = 75e-3
+    pandapipes.create_ext_grid(net2, j0, 5, None, type="p")
+    pandapipes.create_ext_grid(net2, j1, None, temp[1], type="t")
 
-    j0 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=283)
-    j1 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=283)
-    pandapipes.create_ext_grid(net2, j0, 5, 645, type="p")
-    pandapipes.create_ext_grid(net2, j1, 100, 327.765863, type="t")
-    pandapipes.create_sink(net2, j1, 1)
-
-    pandapipes.create_pipe_from_parameters(net2, j0, j1, 6, diameter_m=d, k_mm=.1, sections=1,
-                                           u_w_per_m2k=5)
-    pandapipes.create_fluid_from_lib(net2, "water", overwrite=True)
-    max_iter_hyd = 3 if use_numba else 3
-    max_iter_therm = 12 if use_numba else 12
+    max_iter_therm = 8 if use_numba else 8
     pandapipes.pipeflow(net2, stop_condition="tol", max_iter_hyd=max_iter_hyd,
                         max_iter_therm=max_iter_therm, friction_model="nikuradse",
                         transient=False, nonlinear_method="automatic", tol_p=1e-4, tol_m=1e-4,
@@ -142,11 +134,8 @@ def test_t_type_tee(use_numba):
     j1 = pandapipes.create_junction(net, pn_bar=5, tfluid_k=300)
     j2 = pandapipes.create_junction(net, pn_bar=5, tfluid_k=300)
     j3 = pandapipes.create_junction(net, pn_bar=5, tfluid_k=300)
-    pandapipes.create_ext_grid(net, j0, 5, 645, type="p")
     pandapipes.create_sink(net, j2, 1)
     pandapipes.create_sink(net, j3, 1)
-    pandapipes.create_ext_grid(net, j2, 5, 310, type="t")
-
     pandapipes.create_pipe_from_parameters(net, j0, j1, 6, diameter_m=d, k_mm=.1, sections=1,
                                            u_w_per_m2k=5)
     pandapipes.create_pipe_from_parameters(net, j1, j2, 2.5, diameter_m=d, k_mm=.1, sections=1,
@@ -156,8 +145,13 @@ def test_t_type_tee(use_numba):
 
     pandapipes.create_fluid_from_lib(net, "water", overwrite=True)
 
+    net2 = copy.deepcopy(net)
+
+    pandapipes.create_ext_grid(net, j0, 5, 645, type="p")
+    pandapipes.create_ext_grid(net, j2, 5, 310, type="t")
+
     max_iter_hyd = 4 if use_numba else 4
-    max_iter_therm = 5 if use_numba else 5
+    max_iter_therm = 4 if use_numba else 4
     pandapipes.pipeflow(net, stop_condition="tol", max_iter_hyd=max_iter_hyd,
                         max_iter_therm=max_iter_therm, friction_model="nikuradse",
                         transient=False, nonlinear_method="automatic", tol_p=1e-4,
@@ -165,25 +159,8 @@ def test_t_type_tee(use_numba):
 
     temp = net.res_junction.t_k.values
 
-    net2 = pandapipes.create_empty_network("net")
-    d = 75e-3
+    pandapipes.create_ext_grid(net2, j0, 5, temp[0], type="pt")
 
-    j0 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=300)
-    j1 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=300)
-    j2 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=300)
-    j3 = pandapipes.create_junction(net2, pn_bar=5, tfluid_k=300)
-    pandapipes.create_ext_grid(net2, j0, 5, 380.445, type="pt")
-    pandapipes.create_sink(net2, j2, 1)
-    pandapipes.create_sink(net2, j3, 1)
-
-    pandapipes.create_pipe_from_parameters(net2, j0, j1, 6, diameter_m=d, k_mm=.1, sections=1,
-                                           u_w_per_m2k=5)
-    pandapipes.create_pipe_from_parameters(net2, j1, j2, 2.5, diameter_m=d, k_mm=.1, sections=1,
-                                           u_w_per_m2k=5)
-    pandapipes.create_pipe_from_parameters(net2, j1, j3, 2.5, diameter_m=d, k_mm=.1, sections=1,
-                                           u_w_per_m2k=5)
-
-    pandapipes.create_fluid_from_lib(net2, "water", overwrite=True)
     pandapipes.pipeflow(net2, stop_condition="tol", max_iter_hyd=max_iter_hyd,
                         max_iter_therm=max_iter_therm, friction_model="nikuradse",
                         transient=False, nonlinear_method="automatic", tol_p=1e-4, tol_m=1e-4,

--- a/src/pandapipes/test/api/test_components/test_heat_consumer.py
+++ b/src/pandapipes/test/api/test_components/test_heat_consumer.py
@@ -78,23 +78,23 @@ def test_heat_consumer_equivalence2():
     pandapipes.create_heat_consumer(net, juncs[1], juncs[4], controlled_mdot_kg_per_s=mdot[0], qext_w=qext[0])
     pandapipes.create_heat_consumer(net, juncs[2], juncs[3], controlled_mdot_kg_per_s=mdot[1], qext_w=qext[1])
     pandapipes.pipeflow(net, mode="bidirectional", iter=6)
+    tout1 = net.res_heat_consumer.t_outlet_k.iloc[1]
+    dt1 = net.res_heat_consumer.deltat_k.iloc[1]
 
     pandapipes.create_heat_consumer(net2, juncs[1], juncs[4], controlled_mdot_kg_per_s=mdot[0], qext_w=qext[0])
-    pandapipes.create_heat_consumer(net2, juncs[2], juncs[3], treturn_k=263.4459264973806, qext_w=qext[1])
+    pandapipes.create_heat_consumer(net2, juncs[2], juncs[3], treturn_k=tout1, qext_w=qext[1])
     pandapipes.pipeflow(net2, mode="bidirectional", iter=23)
 
     pandapipes.create_heat_consumer(net3, juncs[1], juncs[4], controlled_mdot_kg_per_s=mdot[0], qext_w=qext[0])
-    pandapipes.create_heat_consumer(net3, juncs[2], juncs[3], deltat_k=17.82611044059695, qext_w=qext[1])
+    pandapipes.create_heat_consumer(net3, juncs[2], juncs[3], deltat_k=dt1, qext_w=qext[1])
     pandapipes.pipeflow(net3, mode="bidirectional", iter=6)
 
     pandapipes.create_heat_consumer(net4, juncs[1], juncs[4], controlled_mdot_kg_per_s=mdot[0], qext_w=qext[0])
-    pandapipes.create_heat_consumer(net4, juncs[2], juncs[3], controlled_mdot_kg_per_s=mdot[1],
-                                    treturn_k=263.4459264973806)
+    pandapipes.create_heat_consumer(net4, juncs[2], juncs[3], controlled_mdot_kg_per_s=mdot[1], treturn_k=tout1)
     pandapipes.pipeflow(net4, mode="bidirectional", iter=7)
 
     pandapipes.create_heat_consumer(net5, juncs[1], juncs[4], controlled_mdot_kg_per_s=mdot[0], qext_w=qext[0])
-    pandapipes.create_heat_consumer(net5, juncs[2], juncs[3], controlled_mdot_kg_per_s=mdot[1],
-                                    deltat_k=17.82611044059695)
+    pandapipes.create_heat_consumer(net5, juncs[2], juncs[3], controlled_mdot_kg_per_s=mdot[1], deltat_k=dt1)
     pandapipes.pipeflow(net5, mode="bidirectional", iter=6)
 
     assert np.allclose(net2.res_junction, net.res_junction)

--- a/src/pandapipes/test/api/test_components/test_pipe.py
+++ b/src/pandapipes/test/api/test_components/test_pipe.py
@@ -78,6 +78,50 @@ def test_pipe_velocity_results(use_numba):
     assert np.all(np.abs(diff_to) < 1e-9)
 
 
+
+@pytest.mark.parametrize("use_numba", [True, False])
+def test_pipe_sections_temperature(use_numba):
+    """
+        This test verifies the results of the temperatures for a pipe network with pipes consisting
+        of more than one section. The basic idea is that the computation is first done with only one
+        section per pipe. Afterwards, the same network is calculated with more nodes. if everything
+        works correctly, the entries in the result table for the velocities (from, to) should be the
+        same.
+
+        A T-junction is used for the test setup
+        :return:
+        :rtype:
+        """
+    net = pandapipes.create_empty_network("net", add_stdtypes=False)
+    d = 209.1e-3
+    pandapipes.create_junction(net, pn_bar=5, tfluid_k=285.15)
+    pandapipes.create_junction(net, pn_bar=5, tfluid_k=285.15)
+    pandapipes.create_pipe_from_parameters(net, 0, 1, 6.0, d, k_mm=.5, sections=1, u_w_per_m2k=5, text_k=285.15)
+    pandapipes.create_ext_grid(net, 0, p_bar=5, t_k=385.15, type="pt")
+    pandapipes.create_sink(net, 1, mdot_kg_per_s=2)
+    pandapipes.create_fluid_from_lib(net, "water")
+
+    net2 = copy.deepcopy(net)
+    net3 = copy.deepcopy(net)
+    net2.pipe.sections = 100
+    net4 = copy.deepcopy(net2)
+    net4.pipe.qext_w = 10000
+    net3.pipe.qext_w = 10000
+
+    max_iter_hyd = 3 if use_numba else 3
+    max_iter_therm = 3 if use_numba else 3
+    pf_args = {
+        "mode": "sequential",
+        "max_iter_hyd": max_iter_hyd,
+        "max_iter_therm": max_iter_therm,
+        "use_numba": use_numba
+    }
+    pandapipes.pipeflow(net, **pf_args)
+    pandapipes.pipeflow(net2, **pf_args)
+    pandapipes.pipeflow(net3, **pf_args)
+    pandapipes.pipeflow(net4, **pf_args)
+
+
 @pytest.fixture
 def create_net_3_juncs():
     net = pandapipes.create_empty_network()

--- a/src/pandapipes/test/api/test_create.py
+++ b/src/pandapipes/test/api/test_create.py
@@ -315,7 +315,7 @@ def test_create_pipes_from_parameters(create_empty_net):
     p = pandapipes.create_pipes_from_parameters(
         net, [j1, j1], [j2, j2], length_km=5, diameter_m=0.8, in_service=False,
         geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-        u_w_per_m2k=0.1, text_k=273, qext_w=0.01)
+        u_w_per_m2k=0.1, text_k=273)
 
     assert len(net.pipe) == 2
     assert len(net.pipe_geodata) == 2
@@ -339,8 +339,6 @@ def test_create_pipes_from_parameters(create_empty_net):
     assert net.pipe.at[p[1], "u_w_per_m2k"] == 0.1
     assert net.pipe.at[p[0], "text_k"] == 273
     assert net.pipe.at[p[1], "text_k"] == 273
-    assert net.pipe.at[p[0], "qext_w"] == 0.01
-    assert net.pipe.at[p[1], "qext_w"] == 0.01
 
     # setting params as array
     net = copy.deepcopy(create_empty_net)
@@ -351,7 +349,7 @@ def test_create_pipes_from_parameters(create_empty_net):
         in_service=[True, False],
         geodata=[[(10, 10), (20, 20)], [(100, 10), (200, 20)]], name=["p1", "p2"],
         k_mm=[0.01, 0.02], loss_coefficient=[0.3, 0.5], sections=[1, 2],
-        u_w_per_m2k=[0.1, 0.2], text_k=[273, 274], qext_w=[0.01, 0.02])
+        u_w_per_m2k=[0.1, 0.2], text_k=[273, 274])
 
     assert len(net.pipe) == 2
     assert len(net.pipe_geodata) == 2
@@ -375,8 +373,6 @@ def test_create_pipes_from_parameters(create_empty_net):
     assert net.pipe.at[p[1], "sections"] == 2
     assert net.pipe.at[p[0], "text_k"] == 273
     assert net.pipe.at[p[1], "text_k"] == 274
-    assert net.pipe.at[p[0], "qext_w"] == 0.01
-    assert net.pipe.at[p[1], "qext_w"] == 0.02
 
 
 def test_create_pipes_from_parameters_raise_except(create_empty_net):
@@ -389,17 +385,17 @@ def test_create_pipes_from_parameters_raise_except(create_empty_net):
         pandapipes.create_pipes_from_parameters(
             net, [1, 3], [4, 5], length_km=5, diameter_m=0.8, in_service=False,
             geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-            u_w_per_m2k=0.1, text_k=273, qext_w=0.01)
+            u_w_per_m2k=0.1, text_k=273)
 
     pandapipes.create_pipes_from_parameters(
         net, [j1, j1], [j2, j3], length_km=5, diameter_m=0.8, in_service=False,
         geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-        u_w_per_m2k=0.1, text_k=273, qext_w=0.01, index=[0, 1])
+        u_w_per_m2k=0.1, text_k=273, index=[0, 1])
     with pytest.raises(UserWarning, match=r"with indexes \[0 1\] already exist"):
         pandapipes.create_pipes_from_parameters(
             net, [j1, j1], [j2, j3], length_km=5, diameter_m=0.8, in_service=False,
             geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-            u_w_per_m2k=0.1, text_k=273, qext_w=0.01, index=[0, 1])
+            u_w_per_m2k=0.1, text_k=273, index=[0, 1])
 
 
 def test_create_pipes(create_empty_net):
@@ -432,8 +428,8 @@ def test_create_pipes(create_empty_net):
     j2 = pandapipes.create_junction(net, 3, 273)
     p = pandapipes.create_pipes(
         net, [j1, j1], [j2, j2], std_type="80_GGG", length_km=5, in_service=False,
-        geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-        u_w_per_m2k=0.1, text_k=273, qext_w=0.01)
+        geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2, text_k=273
+    )
 
     assert len(net.pipe) == 2
     assert len(net.pipe_geodata) == 2
@@ -455,12 +451,8 @@ def test_create_pipes(create_empty_net):
     assert net.pipe.at[p[1], "diameter_m"] == 0.086
     assert net.pipe.at[p[0], "sections"] == 2
     assert net.pipe.at[p[1], "sections"] == 2
-    assert net.pipe.at[p[0], "u_w_per_m2k"] == 0.1
-    assert net.pipe.at[p[1], "u_w_per_m2k"] == 0.1
     assert net.pipe.at[p[0], "text_k"] == 273
     assert net.pipe.at[p[1], "text_k"] == 273
-    assert net.pipe.at[p[0], "qext_w"] == 0.01
-    assert net.pipe.at[p[1], "qext_w"] == 0.01
 
     # setting params as array
     net = copy.deepcopy(create_empty_net)
@@ -468,9 +460,9 @@ def test_create_pipes(create_empty_net):
     j2 = pandapipes.create_junction(net, 3, 273)
     p = pandapipes.create_pipes(
         net, [j1, j1], [j2, j2], std_type="80_GGG", length_km=[1, 5], in_service=[True, False],
-        geodata=[[(10, 10), (20, 20)], [(100, 10), (200, 20)]], name=["p1", "p2"],
-        k_mm=[0.01, 0.02], loss_coefficient=[0.3, 0.5], sections=[1, 2],
-        u_w_per_m2k=[0.1, 0.2], text_k=[273, 274], qext_w=[0.01, 0.02])
+        geodata=[[(10, 10), (20, 20)], [(100, 10), (200, 20)]], name=["p1", "p2"], k_mm=[0.01, 0.02],
+        loss_coefficient=[0.3, 0.5], sections=[1, 2], text_k=[273, 274]
+    )
 
     assert len(net.pipe) == 2
     assert len(net.pipe_geodata) == 2
@@ -490,14 +482,10 @@ def test_create_pipes(create_empty_net):
     assert net.pipe.at[p[1], "k_mm"] == 0.02
     assert net.pipe.at[p[0], "loss_coefficient"] == 0.3
     assert net.pipe.at[p[1], "loss_coefficient"] == 0.5
-    assert net.pipe.at[p[0], "u_w_per_m2k"] == 0.1
-    assert net.pipe.at[p[1], "u_w_per_m2k"] == 0.2
     assert net.pipe.at[p[0], "sections"] == 1
     assert net.pipe.at[p[1], "sections"] == 2
     assert net.pipe.at[p[0], "text_k"] == 273
     assert net.pipe.at[p[1], "text_k"] == 274
-    assert net.pipe.at[p[0], "qext_w"] == 0.01
-    assert net.pipe.at[p[1], "qext_w"] == 0.02
 
 
 def test_create_pipes_raise_except(create_empty_net):
@@ -510,17 +498,17 @@ def test_create_pipes_raise_except(create_empty_net):
         pandapipes.create_pipes(
             net, [1, 3], [4, 5], std_type="80_GGG", length_km=5, in_service=False,
             geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-            u_w_per_m2k=0.1, text_k=273, qext_w=0.01)
+            u_w_per_m2k=0.1, text_k=273)
 
     pandapipes.create_pipes(
         net, [j1, j1], [j2, j3], std_type="80_GGG", length_km=5, in_service=False,
         geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-        u_w_per_m2k=0.1, text_k=273, qext_w=0.01, index=[0, 1])
+        text_k=273, index=[0, 1])
     with pytest.raises(UserWarning, match=r"with indexes \[0 1\] already exist"):
         pandapipes.create_pipes(
             net, [j1, j1], [j2, j3], std_type="80_GGG", length_km=5, in_service=False,
             geodata=[(10, 10), (20, 20)], name="test", k_mm=0.01, loss_coefficient=0.3, sections=2,
-            u_w_per_m2k=0.1, text_k=273, qext_w=0.01, index=[0, 1])
+            text_k=273, index=[0, 1])
 
 
 def test_create_valves(create_empty_net):

--- a/src/pandapipes/test/pipeflow_internals/test_options.py
+++ b/src/pandapipes/test/pipeflow_internals/test_options.py
@@ -82,7 +82,7 @@ def test_iter(create_test_net, use_numba):
     max_iter_hyd = 3 if use_numba else 3
     max_iter_therm = 3 if use_numba else 3
 
-    pandapipes.set_user_pf_options(net, iter=2)
+    pandapipes.set_user_pf_options(net, iter=2, use_numba=use_numba, tol_T=1e-4)
 
     with pytest.raises(PipeflowNotConverged):
         pandapipes.pipeflow(net, mode='sequential')


### PR DESCRIPTION
In a pipe with certain length, the temperature change is induced by the surrounding, which is calculated using the temperature difference and a heat transfer coefficient. Along the pipe, this temperature change underlies a certain curve which leads to an asymptotic narrowing of the temperature difference along the streaming direction. This was not yet considered in the previous derivative calculation function, where the heat flux to the environment was only calculated from the difference between ambient and an intermediate medium temperature. This could in fact lead to situations where the temperature at the end of a pipe falls below the ambient temperature, just due to computational inefficiency. With the adapted formulation comes an important change: The sectioning of pipes is not really relevant anymore. The calculation precision hardly changes with increasing section numbers. This is only true in case of qext_w being set to 0. Therefore, we removed this parameter from the pipe formulation (the only place with length>0 where it was used by now). We believe that this parameter was a misconception, as heat flux is always induced by a temperature difference and can thus be displayed using the given parameters text_k and u_w_per_m2k. We deprecate the parameter in the pandapipes API, assuming that it has hardly ever been used. For components with zero length, qext_w can be given perfectly. There is a small check with a warning inside the derivative calculation in case someone uses their own component model with qext and length>0.