### PR TITLE
Implemented new friction factor calculation spanning entire flow regime

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Change Log
 - [CHANGED] Colebrook-White friction model now uses scipy.optimize.newton for solving the equation
 - [CHANGED] Fluid properties compressibility and viscosity can now process pressure and temperature as inputs, if given the "allow_2d" attribute
 - [CHANGED] Temperature change along pipes now based on exponential function and does not use qext_w anymore
+- [ADDED] Churchill friction factor for application in entire flow regime
 
 [0.12.0] - 2025-06-27
 -------------------------------

--- a/src/pandapipes/converter/stanet/preparing_steps.py
+++ b/src/pandapipes/converter/stanet/preparing_steps.py
@@ -171,7 +171,7 @@ def get_net_params(net, stored_data):
     :return: net parameters
     :rtype:
     """
-    known_friction_models = {1: "swamee-jain", 3: "nikuradse", 5: "colebrook"}
+    known_friction_models = {1: "swamee-jain", 3: "nikuradse", 5: "colebrook", 7:"churchill"}
     compressibility_models = {0: "linear", 1: "AGA", 2: "GERG-88"}
     net_params = dict()
     net_data = stored_data["net_parameters"]

--- a/src/pandapipes/pf/derivative_calculation.py
+++ b/src/pandapipes/pf/derivative_calculation.py
@@ -264,7 +264,21 @@ def calc_der_lambda(m, eta, d, k, friction_model, lambda_pipe, area, re, lengths
                     (eta[pos] * area[pos]) / (d[pos])) ** 0.9 * np.abs(m[pos]) ** -1.9
         return lambda_der
     
-    # elif friction_model == "churchill":
+    elif friction_model == "churchill":
+        param = (7*eta[pos]*area[pos]/(m[pos]*d[pos]))**0.9 + 0.27*k[pos]/d[pos]
+        partial_dparamdm = -0.9*7**0.9 * (d[pos]/(eta[pos] * area[pos]))**(-0.9) * m[pos]**(-1.9)
+
+        paramsAB = ((-2.457*np.log((7*eta[pos]*area[pos]/(m[pos] * d[pos]))**0.9 + 0.27*k[pos]/d[pos]))**16 + (37530*eta[pos]*area[pos]/(m[pos] * d[pos]))**16)
+        paramC = (8*eta[pos]*area[pos]/(m[pos]*d[pos]))**12 + paramsAB**(-1.5)
+        
+        partial_dAdm = 16*(2.457*np.log(param))**15 * 2.457*param**(-1) * partial_dparamdm
+        partial_dBdm = -16*37530**16*(eta[pos]*area[pos]/(m[pos]*d[pos]))**17
+
+        partial_dCdm = -12*(8*eta[pos]*area[pos]/(m[pos]*d[pos]))**11 * (8*eta[pos]*area[pos]/(m[pos]**2*d[pos])) - paramsAB**(-3)*1.5*paramsAB**0.5 * (partial_dAdm + partial_dBdm)
+
+        lambda_der[pos] = 2/3* paramC**(-11/12) * partial_dCdm
+
+        return lambda_der
 
     else:
         lambda_der[pos] = -(64 * eta[pos] * area[pos]) / (m[pos] ** 2 * d[pos])
@@ -319,3 +333,8 @@ def colebrook_white(re, d, k, lambda_nikuradse, max_iter, lengths, tolerance=1e-
         converged = np.all(res.converged)
 
     return converged, lambda_res
+
+
+
+
+

--- a/src/pandapipes/pf/derivative_calculation.py
+++ b/src/pandapipes/pf/derivative_calculation.py
@@ -204,7 +204,7 @@ def calc_lambda(m, eta, d, k, gas_mode, friction_model, lengths, options, area):
         paramA = (-2.457*np.log((7/re)**0.9 + 0.27*k/d))**16
         paramB = (37530/re)**16
         lambda_churchill = 8*((8/re)**12 + 1/(paramA+paramB)**1.5)**(1/12)
-        return lambda_churchill
+        return lambda_churchill, re
 
     else:
         # lambda_tot = np.where(re > 2300, lambda_laminar + lambda_nikuradse, lambda_laminar)

--- a/src/pandapipes/pf/derivative_calculation.py
+++ b/src/pandapipes/pf/derivative_calculation.py
@@ -199,6 +199,13 @@ def calc_lambda(m, eta, d, k, gas_mode, friction_model, lengths, options, area):
         # 1.325 instead of 0.25???
         lambda_swamee_jain = 0.25 / ((np.log10(k / (3.7 * d) + 5.74 / (re ** 0.9))) ** 2)
         return lambda_swamee_jain, re
+    
+    elif friction_model == "churchill":
+        paramA = (-2.457*np.log((7/re)**0.9 + 0.27*k/d))**16
+        paramB = (37530/re)**16
+        lambda_churchill = 8*((8/re)**12 + 1/(paramA+paramB)**1.5)**(1/12)
+        return lambda_churchill
+
     else:
         # lambda_tot = np.where(re > 2300, lambda_laminar + lambda_nikuradse, lambda_laminar)
         lambda_tot = lambda_laminar + lambda_nikuradse
@@ -256,6 +263,9 @@ def calc_der_lambda(m, eta, d, k, friction_model, lambda_pipe, area, re, lengths
         lambda_der[pos] = 0.5 * np.log(10) ** 2 / (np.log(param) ** 3) / param * 5.166 * (
                     (eta[pos] * area[pos]) / (d[pos])) ** 0.9 * np.abs(m[pos]) ** -1.9
         return lambda_der
+    
+    # elif friction_model == "churchill":
+
     else:
         lambda_der[pos] = -(64 * eta[pos] * area[pos]) / (m[pos] ** 2 * d[pos])
         return lambda_der

--- a/src/pandapipes/pf/scratch.py
+++ b/src/pandapipes/pf/scratch.py
@@ -1,0 +1,6 @@
+# %%
+
+
+import numpy as np
+
+

--- a/src/pandapipes/pf/scratch.py
+++ b/src/pandapipes/pf/scratch.py
@@ -1,6 +1,0 @@
-# %%
-
-
-import numpy as np
-
-


### PR DESCRIPTION
The changes include the implementation of a new calculation method for the pipe friction factor for Darcy-Weisbach equation. It spans the entire flow regime for laminar and turbulent flows and the transition region and is an explicit expression.
Total deviations from the Swamee-Jain equation in the turbulent regime and from the solely laminar approach 64/Re can be found in the attached image.

The original publication for this correlation is:
Churchill, S. W. Friction-factor equation spans all fluid-flow regimes, 1977, Chemical Engineering, p. 91-92

<img width="596" height="437" alt="fig_difference_swamee-jain_churchill" src="https://github.com/user-attachments/assets/2eedc75a-4fde-47e0-b4fd-28ae97a8c919" />
[scratch_test_churchill_friction_factor.txt](https://github.com/user-attachments/files/23544694/scratch_test_churchill_friction_factor.txt)
