### PR TITLE
Simplify 'sum_by_group'

### DIFF
--- a/src/pandapipes/component_models/abstract_models/const_flow_models.py
+++ b/src/pandapipes/component_models/abstract_models/const_flow_models.py
@@ -6,8 +6,8 @@ import numpy as np
 from numpy import dtype
 from pandapipes.component_models.abstract_models.node_element_models import NodeElementComponent
 from pandapipes.idx_node import LOAD, ELEMENT_IDX
-from pandapipes.pf.internals_toolbox import _sum_by_group
-from pandapipes.pf.pipeflow_setup import get_lookup, get_net_option
+from pandapipes.pf.internals_toolbox import sum_by_group
+from pandapipes.pf.pipeflow_setup import get_lookup
 
 
 class ConstFlow(NodeElementComponent):
@@ -43,10 +43,10 @@ class ConstFlow(NodeElementComponent):
         helper = loads.in_service.values * loads.scaling.values * cls.sign()
         mf = np.nan_to_num(loads.mdot_kg_per_s.values)
         mass_flow_loads = mf * helper
-        juncts, loads_sum = _sum_by_group(get_net_option(net, "use_numba"), loads.junction.values,
-                                          mass_flow_loads)
+        juncts, (loads_sum,) = sum_by_group(loads.junction.values, mass_flow_loads)
         junction_idx_lookups = get_lookup(net, "node", "index")[
-            cls.get_connected_node_type().table_name()]
+            cls.get_connected_node_type().table_name()
+        ]
         index = junction_idx_lookups[juncts]
         node_pit[index, LOAD] += loads_sum
 

--- a/src/pandapipes/component_models/component_toolbox.py
+++ b/src/pandapipes/component_models/component_toolbox.py
@@ -13,7 +13,7 @@ from pandapipes.idx_branch import LOAD_VEC_NODES_FROM, LOAD_VEC_NODES_TO, FROM_N
 from pandapipes.idx_node import (EXT_GRID_OCCURENCE, EXT_GRID_OCCURENCE_T,
                                  PINIT, NODE_TYPE, P, TINIT, NODE_TYPE_T, T, LOAD)
 from pandapipes.pf.pipeflow_setup import get_net_option, get_lookup
-from pandapipes.pf.internals_toolbox import _sum_by_group
+from pandapipes.pf.internals_toolbox import sum_by_group
 from pandas import Index
 
 
@@ -147,7 +147,6 @@ def set_fixed_node_entries(net, node_pit, junctions, types, values, node_comp, m
         return [], []
 
     junction_idx_lookups = get_lookup(net, "node", "index")[node_comp.table_name()]
-    use_numba = get_net_option(net, "use_numba")
 
     if mode == "p":
         val_col, type_col, count_col, typ, valid_types, values = \
@@ -160,8 +159,11 @@ def set_fixed_node_entries(net, node_pit, junctions, types, values, node_comp, m
 
     mask = np.isin(types, valid_types)
 
-    juncts, val_sum, number = _sum_by_group(use_numba, junctions[mask], values[mask],
-                                            np.ones_like(values[mask], dtype=np.int32))
+    juncts, (val_sum, number) = sum_by_group(
+        junctions[mask],
+        values[mask],
+        np.ones_like(values[mask], dtype=np.int32),
+    )
 
     index = junction_idx_lookups[juncts]
 
@@ -185,8 +187,7 @@ def get_mass_flow_at_nodes(net, node_pit, branch_pit, eg_nodes, comp):
     loads = node_pit[node_uni, LOAD]
     all_index_nodes = np.concatenate([from_nodes, to_nodes, node_uni])
     all_mass_flows = np.concatenate([-mass_flow_from, mass_flow_to, -loads])
-    nodes, sum_mass_flows = _sum_by_group(get_net_option(net, "use_numba"), all_index_nodes,
-                                          all_mass_flows)
+    nodes, (sum_mass_flows,) = sum_by_group(all_index_nodes, all_mass_flows)
     if not np.all(nodes == node_uni):
         raise UserWarning("In component %s: Something went wrong with the mass flow balance. "
                           "Please report this error at github." % comp.__name__)

--- a/src/pandapipes/pf/build_system_matrix.py
+++ b/src/pandapipes/pf/build_system_matrix.py
@@ -12,8 +12,11 @@ from pandapipes.idx_branch import (FROM_NODE, TO_NODE, JAC_DERIV_DM, JAC_DERIV_D
 
 from pandapipes.idx_node import (P, PC as PC_NODE, NODE_TYPE, T, NODE_TYPE_T, LOAD, LOAD_T, INFEED,
                                  MDOTSLACKINIT, JAC_DERIV_MSL, JAC_DERIV_DT_N)
-from pandapipes.pf.internals_toolbox import _sum_by_group_sorted, _sum_by_group, \
-    get_from_nodes_corrected, get_to_nodes_corrected
+from pandapipes.pf.internals_toolbox import (
+    get_from_nodes_corrected,
+    get_to_nodes_corrected,
+    sum_by_group,
+)
 from pandapipes.pf.pipeflow_setup import get_net_option
 
 
@@ -35,7 +38,6 @@ def build_system_matrix(net, branch_pit, node_pit, heat_mode):
     update_option = get_net_option(net, "only_update_hydraulic_matrix")
     update_only = update_option and "hydraulic_data_sorting" in net["_internal_data"] \
                   and "hydraulic_matrix" in net["_internal_data"]
-    use_numba = get_net_option(net, "use_numba")
 
     len_b = len(branch_pit)
     len_n = len(node_pit)
@@ -228,7 +230,10 @@ def build_system_matrix(net, branch_pit, node_pit, heat_mode):
             system_rows = system_rows[data_order]
 
             row_counter = np.zeros(len_b + len_n + len_sl + 1, dtype=np.int32)
-            unique_rows, row_counts = _sum_by_group_sorted(system_rows, np.ones_like(system_rows))
+            unique_rows, (row_counts,) = sum_by_group(
+                system_rows,
+                np.ones_like(system_rows),
+            )
             row_counter[unique_rows + 1] += row_counts
             ptr = row_counter.cumsum()
             system_matrix = csr_matrix((system_data, system_cols, ptr),
@@ -246,18 +251,22 @@ def build_system_matrix(net, branch_pit, node_pit, heat_mode):
         load_vector = np.empty(len_n + len_b + len_sl)
         load_vector[len_n:len_b + len_n] = branch_pit[:, LOAD_VEC_BRANCHES]
         load_vector[:len_n] = node_pit[:, LOAD] * (-1)
-        fn_unique, fn_sums = _sum_by_group(use_numba, fn, branch_pit[:, LOAD_VEC_NODES_FROM])
-        tn_unique, tn_sums = _sum_by_group(use_numba, tn, branch_pit[:, LOAD_VEC_NODES_TO])
+        fn_unique, (fn_sums,) = sum_by_group(fn, branch_pit[:, LOAD_VEC_NODES_FROM])
+        tn_unique, (tn_sums,) = sum_by_group(tn, branch_pit[:, LOAD_VEC_NODES_TO])
         load_vector[fn_unique] -= fn_sums
         load_vector[tn_unique] += tn_sums
         load_vector[slack_nodes] = 0
         load_vector[pc_matrix_indices] = 0
 
         load_vector[slack_mass_matrix_indices] = node_pit[slack_nodes, LOAD] * (-1)
-        fsb_unique, fsb_sums = _sum_by_group(use_numba, slack_masses_from,
-                                             branch_pit[slack_branches_from, LOAD_VEC_NODES_FROM])
-        tsb_unique, tsb_sums = _sum_by_group(use_numba, slack_masses_to,
-                                             branch_pit[slack_branches_to, LOAD_VEC_NODES_TO])
+        fsb_unique, (fsb_sums,) = sum_by_group(
+            slack_masses_from,
+            branch_pit[slack_branches_from, LOAD_VEC_NODES_FROM],
+        )
+        tsb_unique, (tsb_sums,) = sum_by_group(
+            slack_masses_to,
+            branch_pit[slack_branches_to, LOAD_VEC_NODES_TO],
+        )
         load_vector[slack_mass_matrix_indices[fsb_unique]] -= fsb_sums
         load_vector[slack_mass_matrix_indices[tsb_unique]] += tsb_sums
         load_vector[slack_mass_matrix_indices] -= node_pit[slack_nodes, MDOTSLACKINIT]
@@ -265,7 +274,7 @@ def build_system_matrix(net, branch_pit, node_pit, heat_mode):
         load_vector = np.zeros(len_n + len_b)
         load_vector[len_n:] = branch_pit[:, LOAD_VEC_BRANCHES_T]
         load_vector[:len_n] = node_pit[:, LOAD_T] * (-1)
-        tn_unique, tn_sums = _sum_by_group(use_numba, tn, branch_pit[:, LOAD_VEC_NODES_TO_T])
+        tn_unique, (tn_sums,) = sum_by_group(tn, branch_pit[:, LOAD_VEC_NODES_TO_T])
         load_vector[tn_unique] += tn_sums
         load_vector[infeed_node] = 0
 

--- a/src/pandapipes/pf/derivative_toolbox.py
+++ b/src/pandapipes/pf/derivative_toolbox.py
@@ -5,7 +5,7 @@
 import logging
 import numpy as np
 from numpy import linalg
-from pandapipes.pf.internals_toolbox import _sum_by_group
+from pandapipes.pf.internals_toolbox import sum_by_group
 from pandapipes.constants import P_CONVERSION, GRAVITATION_CONSTANT, NORMAL_PRESSURE, \
     NORMAL_TEMPERATURE
 from pandapipes.idx_branch import LENGTH, LAMBDA, D, LOSS_COEFFICIENT as LC, PL, AREA, \
@@ -149,11 +149,11 @@ def derivatives_thermal_np(node_pit, branch_pit,
             fn_deriv = (rho[fn_zero] * area[fn_zero] * cp_b[fn_zero] * (1 / dt) + alpha[fn_zero])
             tn_deriv = (rho[tn_zero] * area[tn_zero] * cp_b[tn_zero] * (1 / dt) + alpha[tn_zero])
 
-            fn_nodes, fn_eq_sum, fn_deriv_sum = _sum_by_group(False,
+            fn_nodes, (fn_eq_sum, fn_deriv_sum) = sum_by_group(
                 from_nodes[fn_zero], fn_eq, fn_deriv
             )
 
-            tn_nodes, tn_eq_sum, tn_deriv_sum = _sum_by_group(False,
+            tn_nodes, (tn_eq_sum, tn_deriv_sum) = sum_by_group(
                 to_nodes[tn_zero], tn_eq, tn_deriv
             )
 

--- a/src/pandapipes/pf/internals_toolbox.py
+++ b/src/pandapipes/pf/internals_toolbox.py
@@ -2,165 +2,81 @@
 # and Energy System Technology (IEE), Kassel, and University of Kassel. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
-import numpy as np
 import logging
 
-from pandapipes.idx_branch import FROM_NODE_T_SWITCHED, TO_NODE, FROM_NODE
+import numpy as np
+import numpy.typing as npt
 
-try:
-    from numba import jit
-    numba_installed = True
-except ImportError:
-    from pandapower.pf.no_numba import jit
-    numba_installed = False
-
+from pandapipes.idx_branch import FROM_NODE, FROM_NODE_T_SWITCHED, TO_NODE
 
 logger = logging.getLogger(__name__)
 
 
-def _sum_by_group_sorted(indices, *values):
-    """Auxiliary function to sum up values by some given indices (both as numpy arrays). Expects the
-    indices and values to already be sorted.
+def sum_by_group(
+    groups: npt.NDArray,
+    *values: npt.NDArray,
+) -> tuple[npt.NDArray, list[npt.NDArray]]:
+    """
+    Sum values by group.
 
-    :param indices:
-    :type indices:
-    :param values:
-    :type values:
+    :param groups: group labels for each element.
+        Will be converted to ``int``.
+    :param values: arrays of items
+        One or more value arrays to sum by group.
     :return:
-    :rtype:
+        A tuple of ``(unique_groups, grouped_sums)``, where:
+
+        - unique_groups
+            sorted unique group labels.
+        - grouped_sums[i]
+            summed values for the i-th input array, same length as ``unique_groups``.
+
+    .. warning::
+        We use ``np.bincount`` which creates an array of ``groups.max() + 1`` size,
+        so having large numbers (> ``1<<24``) in the ``groups`` array is disadvantageous.
+
+    .. note::
+        NaNs are propagated: if an item of some value array is NaN, the sum of this value
+        for a corresponding group will be NaN.
     """
-    # Index defines whether a specific index has already appeared in the index array before.
-    index = np.ones(len(indices), 'bool')
-    index[:-1] = indices[1:] != indices[:-1]
+    if groups.size == 0:
+        return np.empty(0, dtype=int), [np.empty(0, dtype=val.dtype) for val in values]
 
-    # make indices unique for output
-    indices = indices[index]
-
-    val = list(values)
-    for i, _ in enumerate(val):
-        # sum up values, chose only those with unique indices and then subtract the previous sums
-        # --> this way for each index the sum of all values belonging to this index is returned
-        nans = np.isnan(val[i])
-        if np.any(nans):
-            np.nan_to_num(val[i], copy=False)
-            np.cumsum(val[i], out=val[i])
-            val[i] = val[i][index]
-            still_na = nans[index]
-            val[i][1:] = val[i][1:] - val[i][:-1]
-            val[i][still_na] = np.nan
-        else:
-            np.cumsum(val[i], out=val[i])
-            val[i] = val[i][index]
-            val[i][1:] = val[i][1:] - val[i][:-1]
-    return [indices] + val
-
-
-def _sum_by_group_np(indices, *values):
-    """
-    Auxiliary function to sum up values by some given indices (both as numpy arrays).
-
-    :param indices:
-    :type indices:
-    :param values:
-    :type values:
-    :return:
-    :rtype:
-    """
-
-    # sort indices and values by indices
-    order = np.argsort(indices)
-    indices = indices[order]
-    val = list(values)
-    for i, _ in enumerate(val):
-        val[i] = val[i][order]
-
-    return _sum_by_group_sorted(indices, *val)
-
-
-def _sum_by_group_numba(indices, *values):
-    if len(indices) == 0:
-        return tuple([indices] + list(values))
-    # idea: shift this into numba function and raise ValueError if condition not accepted,
-    # has not yet worked...
-    ind_dt = indices.dtype
-    indices = indices.astype(np.int32)
-    max_ind = max_nb(indices)
-    if (max_ind < 1e5 or max_ind < 2 * len(indices)) and max_ind < 10 * len(indices):
-        dtypes = [v.dtype for v in values]
-        val_arr = np.array(list(values), dtype=np.float64).transpose()
-        new_ind, new_arr = _sum_values_by_index(indices, val_arr, max_ind, len(indices),
-                                                len(values))
-        return tuple([new_ind.astype(ind_dt)]
-                     + [new_arr[:, i].astype(dtypes[i]) for i in range(len(values))])
-    return _sum_by_group_np(indices, *values)
-
-def _sum_by_group(use_numba, indices, *values):
-    """
-    Auxiliary function to sum up values by some given indices (both as numpy arrays).
-
-    :param use_numba:
-    :type use_numba:
-    :param indices:
-    :type indices:
-    :param values:
-    :type values:
-    :return:
-    :rtype:
-    """
-    if not use_numba:
-        return _sum_by_group_np(indices, *values)
-    elif not numba_installed:
-        logger.info("The numba import did not work out, it will not be used.")
-        return _sum_by_group_np(indices, *values)
-    else:
-        return _sum_by_group_numba(indices, *values)
+    groups = groups.astype(int, copy=False)
+    unique_groups = np.bincount(groups).nonzero()[0]
+    grouped_sums = [
+        np.bincount(groups, weights=val)[unique_groups].astype(val.dtype, copy=False)
+        for val in values
+    ]
+    return unique_groups, grouped_sums
 
 
 def select_from_pit(table_index_array, input_array, data):
     """
-        Auxiliary function to retrieve values from a table like a pit. Each data entry corresponds
-        to a table_index_array entry. Example: velocities are indexed by the corresponding
-        from_nodes stored in the pipe pit.
+    Auxiliary function to retrieve values from a table like a pit. Each data entry corresponds
+    to a table_index_array entry. Example: velocities are indexed by the corresponding
+    from_nodes stored in the pipe pit.
 
-        The function inputs another array which consists of some table_index_array entries the user
-        wants to retrieve. The function is used in pandapipes results evaluation. The input array is
-        the list of from_junction entries, corresponding only to the junction elements, not
-        containing additional pipe nodes. The table_index_array is the complete list of from_nodes
-        consisting of junction element entries and additional pipe section nodes. Data corresponds
-        to the gas velocities.
+    The function inputs another array which consists of some table_index_array entries the user
+    wants to retrieve. The function is used in pandapipes results evaluation. The input array is
+    the list of from_junction entries, corresponding only to the junction elements, not
+    containing additional pipe nodes. The table_index_array is the complete list of from_nodes
+    consisting of junction element entries and additional pipe section nodes. Data corresponds
+    to the gas velocities.
 
-        :param table_index_array:
-        :type table_index_array:
-        :param input_array:
-        :type input_array:
-        :param data:
-        :type data:
-        :return:
-        :rtype:
-        """
+    :param table_index_array:
+    :type table_index_array:
+    :param input_array:
+    :type input_array:
+    :param data:
+    :type data:
+    :return:
+    :rtype:
+    """
     sorter = np.argsort(table_index_array)
     indices = sorter[np.searchsorted(table_index_array, input_array, sorter=sorter)]
 
     return data[indices]
-
-
-@jit(nopython=True)
-def _sum_values_by_index(indices, value_arr, max_ind, le, n_vals):
-    ind1 = indices + 1
-    new_indices = np.zeros(max_ind + 2, dtype=np.int32)
-    summed_values = np.zeros((max_ind + 2, n_vals), dtype=np.float64)
-    for i in range(le):
-        new_indices[int(ind1[i])] = ind1[i]
-        for j in range(n_vals):
-            summed_values[int(ind1[i]), j] += value_arr[i, j]
-    summed_values = summed_values[new_indices > 0]
-    new_indices = new_indices[new_indices > 0] - 1
-    return new_indices, summed_values
-
-
-@jit(nopython=True)
-def max_nb(arr):
-    return np.max(arr)
 
 
 def get_from_nodes_corrected(branch_pit, switch_from_to_col=None):

--- a/src/pandapipes/pf/result_extraction.py
+++ b/src/pandapipes/pf/result_extraction.py
@@ -17,7 +17,7 @@ from pandapipes.idx_branch import (
     FROM_NODE_T_SWITCHED,
 )
 from pandapipes.idx_node import TABLE_IDX as TABLE_IDX_NODE, PINIT, PAMB, TINIT as TINIT_NODE
-from pandapipes.pf.internals_toolbox import _sum_by_group
+from pandapipes.pf.internals_toolbox import sum_by_group
 from pandapipes.pf.pipeflow_setup import get_table_number, get_lookup, get_net_option
 from pandapipes.properties.fluids import get_fluid
 from pandapipes.properties.properties_toolbox import get_branch_real_density
@@ -230,22 +230,26 @@ def extract_branch_results_with_internals(net, branch_results, table_name,
         if len(res_mean) > 0:
             # results that relate to the whole branch and shall be averaged (by summing up all
             # values and dividing by number of internal sections)
-            use_numba = get_net_option(net, "use_numba")
-            res = _sum_by_group(use_numba, idx_pit, np.ones_like(idx_pit),
-                                comp_connected.astype(np.int32),
-                                *[branch_results[rn[1]][f:t] for rn in res_mean])
-            connected_ind = res[2] > 0.99
-            num_internals = res[1][connected_ind]
+            _, res = sum_by_group(
+                idx_pit,
+                np.ones_like(idx_pit),
+                comp_connected.astype(np.int32),
+                *[branch_results[rn[1]][f:t] for rn in res_mean],
+            )
+            connected_ind = res[1] > 0.99
+            num_internals = res[0][connected_ind]
 
             # hint: idx_pit[placement_table] should result in the indices as ordered in the table
             pt = placement_table[connected_ind]
 
-            for i, (res_name, entry) in enumerate(res_mean_hydraulics):
-                res_table[res_name].values[pt] = res[i + 3][connected_ind] / num_internals
+            for i, (res_name, entry) in enumerate(res_mean_hydraulics, start=2):
+                res_table[res_name].values[pt] = res[i][connected_ind] / num_internals
         if len(res_branch) > 0:
-            use_numba = get_net_option(net, "use_numba")
-            _, sections, connected_sum = _sum_by_group(use_numba, idx_pit, np.ones_like(idx_pit),
-                                comp_connected.astype(np.int32))
+            _, (sections, connected_sum) = sum_by_group(
+                idx_pit,
+                np.ones_like(idx_pit),
+                comp_connected.astype(np.int32),
+            )
             connected_ind = connected_sum > 0.99
             indices_last_section = (np.cumsum(sections) - 1).astype(int)[connected_ind]
             # hint: idx_pit[placement_table] should result in the indices as ordered in the table

--- a/src/pandapipes/test/api/test_aux_function.py
+++ b/src/pandapipes/test/api/test_aux_function.py
@@ -5,7 +5,7 @@
 import numpy as np
 import pytest
 
-from pandapipes.pf.internals_toolbox import select_from_pit
+from pandapipes.pf.internals_toolbox import select_from_pit, sum_by_group
 
 
 @pytest.mark.xfail(reason="The function has been changed. Unclear how to interpret the new version.")
@@ -24,3 +24,176 @@ def test_select_from_pit():
     expected_result = np.array([11, 13, 14])
 
     assert np.all(ret == expected_result)
+
+
+class TestSumByGroup:
+    """Tests for `sum_by_group` function
+
+    Some tests follow a naming convention:
+        one_group, two_groups -- tells number of groups used in the test
+        one_value, two_values -- tells number of values arrays
+        one_item, two_items -- tells number of items in values arrays
+
+        So, `test_one_group_two_values_three_items` would mean the test
+        uses:
+            * group = np.array([1])  or  group = np.array([1, 1, 1])
+            * vals = [np.array([1, 2, 3]), np.array([4, 5, 6])],
+                meaning len(vals) == 2 and len(vals[0]) == len(vals[1]) == 3
+
+    """
+
+    def test_one_group_one_value_one_item(self):
+        """Base test.
+
+        Tests that something does work
+        """
+        gr = np.array([1])
+        val = np.array([1])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [1])
+        assert np.allclose(grouped_sum, [1])
+
+    def test_one_group_one_value_two_items(self):
+        """Test that summing for one group works."""
+        gr = np.array([1, 1])
+        val = np.array([1, 2])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [1])
+        assert np.allclose(grouped_sum, [3])
+
+    def test_one_group_two_distinct_values_one_item(self):
+        """Test that summing for one group still works even with 2 values."""
+        gr = np.array([1])
+        val = [np.array([1]), np.array([2])]
+        unique_groups, (grouped_sum_1, grouped_sum_2) = sum_by_group(gr, *val)
+
+        assert np.allclose(unique_groups, [1])
+        assert np.allclose(grouped_sum_1, [1])
+        assert np.allclose(grouped_sum_2, [2])
+
+    def test_one_group_two_distinct_values_two_items(self):
+        """Test summing for one group with 2 values and with 2 items works."""
+        gr = np.array([1, 1])
+        val = [np.array([1, 2]), np.array([2, 3])]
+        unique_groups, (grouped_sum_1, grouped_sum_2) = sum_by_group(gr, *val)
+
+        assert np.allclose(unique_groups, [1])
+        assert np.allclose(grouped_sum_1, [3])
+        assert np.allclose(grouped_sum_2, [5])
+
+    def test_two_groups_two_distinct_values_two_items(self):
+        """Test that we get sums per group and per value.
+
+        A general test
+        """
+        gr = np.array([1, 2])
+        val = [np.array([1, 3]), np.array([2, 4])]
+        unique_groups, (grouped_sum_1, grouped_sum_2) = sum_by_group(gr, *val)
+
+        assert np.allclose(unique_groups, [1, 2])
+        assert np.allclose(grouped_sum_1, [1, 3])
+        assert np.allclose(grouped_sum_2, [2, 4])
+
+    def test_two_groups_two_distinct_values_nan_item(self):
+        """Test that NaNs are preserved and don't get in the way."""
+        gr = np.array([1, 2, 2])
+        val = [np.array([1, 2, 3]), np.array([2, 4, np.nan])]
+        unique_groups, (grouped_sum_1, grouped_sum_2) = sum_by_group(gr, *val)
+
+        assert np.allclose(unique_groups, [1, 2])
+        assert np.allclose(grouped_sum_1, [1, 5])
+        assert np.allclose(grouped_sum_2, [2, np.nan], equal_nan=True)
+
+    def test_unsorted_groups(self):
+        """Test that the groups can be unsorted."""
+        gr = np.array([2, 1, 2])
+        val = np.array([1, 2, 3])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [1, 2])
+        assert np.allclose(grouped_sum, [2, 4])
+
+    def test_nonconsecutive_groups(self):
+        """Test that groups don't need to be consecutive."""
+        gr = np.array([5, 1, 5])
+        val = np.array([1, 2, 3])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [1, 5])
+        assert np.allclose(grouped_sum, [2, 4])
+
+    def test_all_nan_items(self):
+        """Test we can handle all NaN items."""
+        gr = np.array([1, 1, 1])
+        val = np.array([np.nan, np.nan, np.nan])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [1])
+        assert np.allclose(grouped_sum, [np.nan], equal_nan=True)
+
+    def test_empty_input_one_value(self):
+        """Test we handle both empty groups and empty value."""
+        gr = np.array([])
+        val = np.array([])
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert np.allclose(unique_groups, [])
+        assert np.allclose(grouped_sum, [])
+
+    def test_empty_input_two_values(self):
+        """Test we handle both empty groups and return the input number of empty values."""
+        gr = np.array([])
+        val = [np.array([]), np.array([])]
+        unique_groups, (grouped_sum_1, grouped_sum_2) = sum_by_group(gr, *val)
+
+        assert np.allclose(unique_groups, [])
+        assert np.allclose(grouped_sum_1, [])
+        assert np.allclose(grouped_sum_2, [])
+
+    def test_value_dtype_preserved(self):
+        """Test we preserve dtype for a single value."""
+        gr = np.array([1])
+        val = np.array([1], dtype=np.uint32)
+
+        unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+        assert grouped_sum.dtype == np.uint32
+
+    def test_values_dtypes_preserved(self):
+        """Test we preserve dtypes (distinct!) for several values."""
+        gr = np.array([1])
+        val = (np.array([1], dtype=np.float32), np.array([1], dtype=np.uint32))
+
+        unique_groups, (fl32, ui32) = sum_by_group(gr, *val)
+
+        assert fl32.dtype == np.float32
+        assert ui32.dtype == np.uint32
+
+    def test_empty_input_dtypes_preserved(self):
+        """Test we preserve dtypes (distinct!) even for empty input."""
+        gr = np.array([], dtype=int)
+        val = (np.array([], dtype=np.float32), np.array([], dtype=np.uint32))
+
+        unique_groups, (fl32, ui32) = sum_by_group(gr, *val)
+
+        assert unique_groups.dtype == int
+        assert fl32.dtype == np.float32
+        assert ui32.dtype == np.uint32
+
+    def test_negative_groups(self):
+        """Test we don't support negative groups."""
+        gr = np.array([-1, -2, -3])
+        val = np.array([1, 2, 3])
+
+        with pytest.raises(ValueError, match="must have no negative elements"):
+            unique_groups, (grouped_sum,) = sum_by_group(gr, val)
+
+    def test_len_mismatch(self):
+        """Test we don't allow groups and values of different lengths."""
+        gr = np.array([1, 1])
+        val = np.array([2])
+
+        with pytest.raises(ValueError, match="don't have the same length"):
+            unique_groups, (grouped_sum,) = sum_by_group(gr, val)


### PR DESCRIPTION
This PR replaces the `_sum_by_group` function. The main goals are to improve readability and maintainability;  performance was improved as well 

## Readability and maintenance
IMO, it became more clear what the code does (maybe I became more familiar with the code and my judgement is skewed). Also all the work is now being done by one function, not scattered around: this should ease maintenance, since there's less code now

I added tests as well. This better documents the function and makes future changes more confident.

## Performance
### How I measured
I collected all the `indices` and `values` passed to `_sum_by_group_np` and made this my testing data.

<details><summary>Testing data collection</summary>
<p>

Assuming we're on a commit prior current one (https://github.com/e2nIEE/pandapipes/commit/a83733bed40971dd1c46eef6f9d7fe7eed717de7), so we still have the old `_sum_by_group_np`.
The code below would save `indices` and `values` under "data" directory. I'm getting ~28k small files: 14k for indices and 14k for values.
```py
from pathlib import Path

p = Path(__file__)
root = Path(*p.parts[: p.parts.index("pandapipes") + 1])
data_dir = root / "data"
data_dir.mkdir(exist_ok=True)
n_inputs = 0

def _sum_by_group_np(indices, *values):
    global n_inputs

    np.save(data_dir / f"{n_inputs:05}_inds.npy", indices)
    np.save(data_dir / f"{n_inputs:05}_vals.npy", np.vstack(values))
    n_inputs += 1
```
</p>
</details>

Then I created a file under the project root to test different function implementations, let's call it "test_sum_by_group.py". It's content is under the spoiler below. I test the function on all inputs 10 times (this is one round), do 3 such rounds and take a minimum.

<details><summary>Performance test file</summary>
<p>

The function implementations are shown in the next collapsible sections.

```py
import numpy as np
import numba as nb

def ind_val():
    """Collect our data from previous step"""
    from collections import defaultdict

    root = Path("data")
    data = defaultdict(lambda: [None, None])

    for f in root.iterdir():
        idx, is_val = f.stem.split("_")
        data_idx = is_val == "vals"
        data[int(idx)][data_idx] = np.load(f)

    inds = []
    vals = []
    for ind, val in data.values():
        inds.append(ind)
        vals.append(val)

    return inds, vals

def main():
    """Main function where the testing takes place"""
    from timeit import repeat
    inds, vals = ind_val()

    def tf(f):
        """A helper function to time all inputs"""
        for _ind, _val in zip(inds, vals):
            f(_ind, _val)

    fs = (
        old,
        new_bincount,
        new_cumsum,
        nmb,
    )
    for f in fs:
        res = repeat(
            f"tf({f.__name__})",
            repeat=3,
            number=10,
            globals={"tf": tf} | {f.__name__: f for f in fs},
        )
        print(f"{f.__name__}: {'. '.join(map(lambda v: f'{v:.5f}', res))}")


main()
```

Functions:

<details><summary>old</summary>
<p>

This is the previous `_sum_by_group_np`
```py
def _sum_by_group_sorted(indices, *values):
    """Auxiliary function to sum up values by some given indices (both as numpy arrays). Expects the
    indices and values to already be sorted.

    :param indices:
    :type indices:
    :param values:
    :type values:
    :return:
    :rtype:
    """
    # Index defines whether a specific index has already appeared in the index array before.
    index = np.ones(len(indices), "bool")
    index[:-1] = indices[1:] != indices[:-1]

    # make indices unique for output
    indices = indices[index]

    val = list(values)
    for i, _ in enumerate(val):
        # sum up values, chose only those with unique indices and then subtract the previous sums
        # --> this way for each index the sum of all values belonging to this index is returned
        nans = np.isnan(val[i])
        if np.any(nans):
            np.nan_to_num(val[i], copy=False)
            np.cumsum(val[i], out=val[i])
            val[i] = val[i][index]
            still_na = nans[index]
            val[i][1:] = val[i][1:] - val[i][:-1]
            val[i][still_na] = np.nan
        else:
            np.cumsum(val[i], out=val[i])
            val[i] = val[i][index]
            val[i][1:] = val[i][1:] - val[i][:-1]
    return [indices] + val


def old(indices, values):
    # sort indices and values by indices
    order = np.argsort(indices)
    inds = indices[order]
    val = list(values)
    for i, _ in enumerate(val):
        val[i] = val[i][order]

    res = _sum_by_group_sorted(inds, *val)
    return res

```

</p>
</details> 


<details><summary>new_bincount</summary>
<p>

```py
def new_bincount(indices, values):
    if indices.size == 0:
        return np.empty(0, dtype=int), [np.empty(0, dtype=val.dtype) for val in values]

    groups = indices.astype(int, copy=False)
    unique_indices = np.bincount(groups).nonzero()[0]
    vals = [
        np.bincount(groups, weights=val)[unique_indices].astype(val.dtype, copy=False)
        for val in values
    ]
    return unique_indices, vals
```

</p>
</details> 

<details><summary>new_cumsum</summary>
<p>

```py
def new_cumsum(indices, values):
    if indices.size == 0:
        return (
            np.empty(0, dtype=indices.dtype),
            [np.empty(0, dtype=val.dtype) for val in values],
        )
    order = np.argsort(indices)
    groups = indices[order]

    unique_idx = np.empty(groups.size, dtype=bool)
    unique_idx[0] = True
    np.not_equal(groups[1:], groups[:-1], out=unique_idx[1:])
    group_idx = unique_idx.nonzero()[0]

    return (
        groups[unique_idx],
        [np.add.reduceat(val[order], group_idx, dtype=val.dtype) for val in values],
    )
```

</p>
</details> 

Numba-powered version of `new_bincount` (basically just adding a decorator)
<details><summary>nmb</summary>
<p>

```py
@nb.njit
def nmb(indices, values):
    if indices.size == 0:
        return np.empty(0, dtype=np.int64), [
            np.empty(0, dtype=val.dtype) for val in values
        ]

    iinds = indices.astype(np.int64)
    idx = np.bincount(iinds)
    unique_indices = np.flatnonzero(idx)
    vals = [
        np.bincount(iinds, weights=val)[unique_indices].astype(val.dtype)
        for val in values
    ]
    return unique_indices, vals
```

</p>
</details> 

There is no support for `np.add.reduceat` in numba and the regular `np.cumsum` with subtracting works even worse, so there's no numba-powered version of `new_cumsum`.

</p>
</details> 


To run the testing suite I used `uv run test_sum_by_group.py`

### Results
Here're the results I obtained on my machine (measurement unit is seconds):

```
old: 2.15977, 2.15104, 2.17834
new_bincount: 0.40900, 0.40652, 0.41300
new_cumsum: 0.96587, 0.94974, 0.94659
nmb: 1.58427, 0.30429, 0.30589
```

* `new_bincount` gives ~5x speedup; in terms of time-per-call (time / 10 (in one round I run a function 10 times)  / 10_000 (roughly a number of inputs) we get 21 us vs. 4 us, which is pretty fast, if you ask me.
* `nmb` does run faster than the `new_bincount` by 30%, but the absolute speedup is marginal: 4 us time-per-call vs. 3 us. We should also take the compilation time into account here. It takes ~1.2 sec to compile, meaning numba version would 
outperform non-numba version only after `1.2 / (0.4 - 0.3) = 12` runs of performance test suite! 
This numba over non-numba gain deemed miniscule to me, so I decided not to include the numba version at all.
* While `new_cumsum` is 2x slower than `new_bincount` it has a serious advantage: `new_bincount` needs to allocate an array of `indices.max() + 1` size (128 MiB for size 2\*\*24 of dtype np.int64). With arrays this big we're spending more time allocating, than running an algorithm. `new_cumsum` doesn't suffer from this problem, but even with array of 2\*\*24 size `new_bincount` was still faster. Arrays of this size (more correctly, indices with such numbers) are unlikely to be used and we would lose lots of performance, so I chose `new_bincount` over  `new_cumsum`.

### Performance of `uv run pytest`
The testing suite (`uv run pytest`) became a whopping 1s faster!

I measured 10 runs with hyperfine. This result is without this PR:
```
Benchmark 1: uv run pytest --quiet --disable-warnings src/pandapipes/test
  Time (mean ± σ):     46.235 s ±  0.232 s    [User: 42.459 s, System: 3.130 s]
  Range (min … max):   45.927 s … 46.635 s    10 runs
```

And this one is with this commit:
```
Benchmark 1: uv run pytest --quiet --disable-warnings src/pandapipes/test
  Time (mean ± σ):     44.770 s ±  0.203 s    [User: 41.297 s, System: 2.867 s]
  Range (min … max):   44.445 s … 45.073 s    10 runs
```

## API change
* Made `sum_by_group` a public function (no particular reason)
* Changed the results signature

The previous version returned both unique indices and grouped sums as one list: `[indices] + grouped_sums`. I made the new function return a tuple of unique indices and grouped sums as separate objects: `(indices, grouped_sums)`. All internal usages were updated.
See the change from the caller side in these diffs:

```diff
-juncts, loads_sum = _sum_by_group(loads.junction.values, mass_flow_loads)
+juncts, (loads_sum,) = sum_by_group(loads.junction.values, mass_flow_loads)
```
```diff
-tn_nodes, tn_eq_sum, tn_deriv_sum = _sum_by_group(
+tn_nodes, (tn_eq_sum, tn_deriv_sum) = sum_by_group(
```
This was done to ease numba-powering the functions, but IMO it also more clearly separates the output: we get `unique_indices` as separate entity and `grouped_sums` as another entity. Though, either returning method is equivalent performance-wise

 If any of the API changes are unnecessary, I'm happy to revert them